### PR TITLE
Placeholder: Feature/coverage

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ coverage==5.0.4
 coveralls==2.0.0
 flake8==3.7.9
 pre-commit==2.2.0
+pygraphviz==1.5
 pytest==5.4.1
 pytest-cov==2.8.1
 typeguard==2.7.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,6 @@ coverage==5.0.4
 coveralls==2.0.0
 flake8==3.7.9
 pre-commit==2.2.0
-pygraphviz==1.5
 pytest==5.4.1
 pytest-cov==2.8.1
 typeguard==2.7.1

--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -12,7 +12,6 @@ from snowfakery.data_gen_exceptions import DataGenError
 from snowfakery.data_generator import generate, StoppingCriteria
 import sys
 from pathlib import Path
-from typing import Tuple
 
 import yaml
 import click
@@ -45,7 +44,9 @@ def eval_arg(arg):
         return arg
 
 
-def string_int_tuple(ctx, param, value: Tuple[str, str] = None):
+# don't add a type signature to this function.
+# typeguard and click will interfer with each other.
+def string_int_tuple(ctx, param, value=None):
     """Works around Click bug
 
     https://github.com/pallets/click/issues/789#issuecomment-535121714"""
@@ -90,14 +91,6 @@ def string_int_tuple(ctx, param, value: Tuple[str, str] = None):
     type=click.Path(exists=False),
 )
 @click.option(
-    "--start-id",
-    "start_ids",
-    nargs=2,
-    type=eval_arg,
-    multiple=True,
-    help="A pair that represents a table name and a number of rows to generate",
-)
-@click.option(
     "--generate-continuation-file",
     type=click.File("w"),
     help="A file that captures information about how to continue a "
@@ -119,7 +112,6 @@ def generate_cli(
     generate_cci_mapping_file=None,
     output_format=None,
     output_files=None,
-    start_ids=None,
     nickname_ids=None,
     continuation_file=None,
     generate_continuation_file=None,
@@ -138,7 +130,6 @@ def generate_cli(
     Diagram output depends on the installation of pygraphviz ("pip install pygraphviz")
     """
     output_files = list(output_files) if output_files else []
-    start_ids = list(start_ids) if start_ids else []
     stopping_criteria = StoppingCriteria(*target_number) if target_number else None
     output_format = output_format.lower() if output_format else None
     validate_options(

--- a/snowfakery/data_generator.py
+++ b/snowfakery/data_generator.py
@@ -1,6 +1,7 @@
 import warnings
-from typing import IO, Tuple, Mapping, List, Dict, TextIO
+from typing import IO, Tuple, Mapping, List, Dict, TextIO, Union
 from importlib import import_module
+from click.utils import LazyFile
 
 from yaml import safe_dump, safe_load
 from faker.providers import BaseProvider as FakerProvider
@@ -120,7 +121,7 @@ def generate(
     user_options: dict = None,
     output_stream: OutputStream = None,
     stopping_criteria: StoppingCriteria = None,
-    generate_continuation_file: TextIO = None,
+    generate_continuation_file: Union[TextIO, LazyFile] = None,
     continuation_file: TextIO = None,
 ) -> ExecutionSummary:
     """The main entry point to the package for Python applications."""

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from abc import abstractmethod, ABC
 import json
 import csv
@@ -230,7 +229,6 @@ class JSONOutputStream(FileOutputStream):
 
     def close(self) -> None:
         self.stream.write("]\n")
-        sys.stderr.write("CLOSING")
         super().close()
 
 

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -397,8 +397,6 @@ class ImageOutputStream(GraphvizOutputStream):
         super().__init__(path)
 
     def close(self) -> None:
-        if isinstance(self.path, Path):
-            self.path = str()
         self.G.draw(path=self.stream, prog="dot", format=self.format)
 
 

--- a/snowfakery/utils/template_utils.py
+++ b/snowfakery/utils/template_utils.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Sequence, Mapping
+from typing import Sequence
 import string
 
 from faker import Faker
@@ -49,14 +49,6 @@ class FakerTemplateLibrary:
 
 
 Template = lru_cache(512)(Template)
-
-
-def format_str(value, variables: Mapping, fake: Faker):
-    variables = variables or {}
-    if isinstance(value, str) and "{" in value:
-        value = Template(value).render(fake=fake, **variables)
-
-    return value
 
 
 number_chars = set(string.digits + ".")

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,0 +1,5 @@
+class TestMainModule:
+    def test_main_module(self):
+        from snowfakery import __main__
+
+        __main__

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,5 +1,11 @@
-class TestMainModule:
-    def test_main_module(self):
-        from snowfakery import __main__
+import pytest
 
-        __main__
+
+class TestMainModule:
+    def test_main_module(self, capsys):
+        with pytest.raises(SystemExit):
+            from snowfakery import __main__ as _unused
+
+            _unused = _unused  # flake8
+
+        assert "Usage:" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -272,3 +272,40 @@ class TestGenerateFromCLI:
             main()
 
         assert "Usage:" in capsys.readouterr().err
+
+
+class TestCLIOptionChecking:
+    def test_mapping_file_no_dburl(self):
+        with pytest.raises(ClickException):
+            generate_cli.main(
+                ["--mapping_file", str(str(sample_yaml)), str(sample_yaml)],
+                standalone_mode=False,
+            )
+
+    def test_mutually_exclusive(self):
+        with pytest.raises(ClickException) as e:
+            with TemporaryDirectory() as t:
+                generate_cli.main(
+                    [
+                        str(sample_yaml),
+                        "--dburl",
+                        f"sqlite:///{t}/foo.db",
+                        "--output-format",
+                        "JSON",
+                    ],
+                    standalone_mode=False,
+                )
+        assert "mutually exclusive" in str(e.value)
+
+        with pytest.raises(ClickException) as e:
+            generate_cli.main(
+                [
+                    str(sample_yaml),
+                    "--cci-mapping-file",
+                    str(sample_yaml),
+                    "--output-format",
+                    "JSON",
+                ],
+                standalone_mode=False,
+            )
+        assert "apping-file" in str(e.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,7 +205,8 @@ class TestGenerateFromCLI:
                 standalone_mode=False,
             )
 
-    def test_from_cli__many_outputs(self):
+    @pytest.mark.importorskip("pygraphviz")
+    def test_image_outputs(self):
         with TemporaryDirectory() as t:
             png = Path(t) / "out.png"
             svg = Path(t) / "out.svg"
@@ -255,11 +256,16 @@ class TestGenerateFromCLI:
         assert "output-format" in str(e.value)
 
     def test_cli_errors__mutex3(self):
-        with pytest.raises(ClickException) as e:
-            generate_cli.main(
-                [str(sample_yaml), "--cci-mapping-file", "-"], standalone_mode=False,
-            )
-        assert "--cci-mapping-file" in str(e.value)
+        with named_temporary_file_path() as tempfile:
+            with open(tempfile, "w") as t:
+                t.write("")
+
+            with pytest.raises(ClickException) as e:
+                generate_cli.main(
+                    [str(sample_yaml), "--cci-mapping-file", tempfile],
+                    standalone_mode=False,
+                )
+            assert "--cci-mapping-file" in str(e.value)
 
     def test_module_main(self, capsys):
         with pytest.raises(SystemExit):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,8 +205,8 @@ class TestGenerateFromCLI:
                 standalone_mode=False,
             )
 
-    @pytest.mark.importorskip("pygraphviz")
     def test_image_outputs(self):
+        pytest.importorskip("pygraphviz")
         with TemporaryDirectory() as t:
             png = Path(t) / "out.png"
             svg = Path(t) / "out.svg"

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -132,12 +132,12 @@ class TestSqlOutputStream(unittest.TestCase, OutputCommonTests):
             table_names = results.tables.keys()
             output_stream.close()
             engine = create_engine(url)
-            connection = engine.connect()
-            tables = {
-                table_name: list(connection.execute(f"select * from {table_name}"))
-                for table_name in table_names
-            }
-            return tables
+            with engine.connect() as connection:
+                tables = {
+                    table_name: list(connection.execute(f"select * from {table_name}"))
+                    for table_name in table_names
+                }
+                return tables
 
 
 class JSONTables:

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -5,8 +5,9 @@ import json
 import datetime
 import csv
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 from contextlib import redirect_stdout
+from tests.utils import named_temporary_file_path
 
 from sqlalchemy import create_engine
 
@@ -124,8 +125,8 @@ class OutputCommonTests(ABC):
 
 class TestSqlOutputStream(unittest.TestCase, OutputCommonTests):
     def do_output(self, yaml):
-        with NamedTemporaryFile() as f:
-            url = f"sqlite:///{f.name}"
+        with named_temporary_file_path() as f:
+            url = f"sqlite:///{f}"
             output_stream = SqlOutputStream.from_url(url, None)
             results = generate(StringIO(yaml), {}, output_stream)
             table_names = results.tables.keys()

--- a/tests/test_with_cci.py
+++ b/tests/test_with_cci.py
@@ -1,15 +1,14 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 import unittest
-from click import ClickException
 from sqlalchemy import create_engine
 
 
-from snowfakery.cli import generate_cli, eval_arg
+from snowfakery.cli import generate_cli
 
 try:
     import cumulusci
-except:
+except ImportError:
     cumulusci = False
 
 sample_mapping_yaml = Path(__file__).parent / "mapping_vanilla_sf.yml"
@@ -39,40 +38,3 @@ class Test_CLI_CCI(unittest.TestCase):
             result = list(connection.execute("select * from Account"))
             assert result[0]["id"] == 1
             assert result[0]["BillingCountry"] == "Canada"
-
-    @unittest.skipUnless(cumulusci, "CumulusCI not installed")
-    def test_mapping_file_no_dburl(self):
-        with self.assertRaises(ClickException):
-            generate_cli.main(
-                ["--mapping_file", str(sample_mapping_yaml), str(sample_yaml)],
-                standalone_mode=False,
-            )
-
-    @unittest.skipUnless(cumulusci, "CumulusCI not installed")
-    def test_mutually_exclusive(self):
-        with self.assertRaises(ClickException) as e:
-            with TemporaryDirectory() as t:
-                generate_cli.main(
-                    [
-                        str(sample_yaml),
-                        "--dburl",
-                        f"csvfile://{t}/csvoutput",
-                        "--output-format",
-                        "JSON",
-                    ],
-                    standalone_mode=False,
-                )
-        assert "mutually exclusive" in str(e.exception)
-
-        with self.assertRaises(ClickException) as e:
-            generate_cli.main(
-                [
-                    str(sample_yaml),
-                    "--cci-mapping-file",
-                    sample_mapping_yaml,
-                    "--output-format",
-                    "JSON",
-                ],
-                standalone_mode=False,
-            )
-        assert "apping file" in str(e.exception)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+from tempfile import TemporaryDirectory
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def named_temporary_file_path(*, prefix="", suffix=""):
+    """Context manager that yields a tempfile Path-like object
+
+    Windows generally doesn't like files to be opened twice.
+    Standard "NamedTemporaryFiles" are therefore of limited
+    utility, because its hard to use them in a portable way."""
+
+    with TemporaryDirectory() as d:
+        yield Path(d) / (prefix + "tempfile" + suffix)


### PR DESCRIPTION
Increasing test coverage and Windows support and fixing bugs found in that process.

In the file cli.py, I removed the broken --start-ids feature and use a context manager for outputstreams to close them. Let Output Streams open and close their old file handles.

In datagenerator.py I allow click's LazyFile which is not a proper subclass of Python TextIO

In OutputStreams I have a base class that manages open and closing file handles. Also cleaned up connection handling somewhat in SQLOutputStream and create everything (base, metadata, etc.) in the initializer rather than in the middle of the code.

In test files, increase coverage and remove uses of NamedTemporaryFile which is basically unusable on Windows. I created a new utility (in test/utils.py) for that.
