### PR TITLE
Feature/faker yaml compatibility

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@ In the beginning, programmers created the databases. Now the databases were form
 
 And so [Salesforce.org](http://salesforce.org/) said “Let there be data,” and there was Snowfakery. And it was good.
 
+## Snowfakery 0.6.1
+
+Bugfix (not user visible) and code cleanup.
+
 ## Snowfakery 0.6
 
 Snowfakery 0.6 is open source!

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 
 from typing import Optional, Dict, List, Sequence, Mapping, NamedTuple
 
+from faker.utils.datetime_safe import date as faker_date
 import jinja2
 import yaml
 
@@ -111,6 +112,11 @@ class Dependency(NamedTuple):
 
 yaml.SafeDumper.add_representer(
     Dependency, lambda representer, obj: representer.represent_list(obj)
+)
+
+
+yaml.SafeDumper.add_representer(
+    faker_date, yaml.representer.SafeRepresenter.represent_date
 )
 
 

--- a/snowfakery/parse_factory_yaml.py
+++ b/snowfakery/parse_factory_yaml.py
@@ -106,7 +106,7 @@ class ParseContext:
         finally:
             self.current_parent_object = _old_parsed_template
 
-    def register_object(self, template: ObjectTemplate) -> None:
+    def register_template(self, template: ObjectTemplate) -> None:
         """Register templates for later use.
 
         We register templates so we can get a list of all fields that can
@@ -293,7 +293,7 @@ def parse_object_template(yaml_sobj: Dict, context: ParseContext) -> ObjectTempl
         if count_expr is not None:
             parse_count_expression(yaml_sobj, sobj_def, context)
         new_template = ObjectTemplate(**sobj_def)
-        context.register_object(new_template)
+        context.register_template(new_template)
         return new_template
 
 

--- a/snowfakery/version.py
+++ b/snowfakery/version.py
@@ -1,1 +1,1 @@
-version = 0.6
+version = "0.6.1"

--- a/tests/gender_conditional.yml
+++ b/tests/gender_conditional.yml
@@ -1,0 +1,28 @@
+- object: Person
+  fields:
+    gender:
+      random_choice:
+        - choice:
+            probability: 40%
+            pick: Male
+        - choice:
+            probability: 40%
+            pick: Female
+        - choice:
+            probability: 20%
+            pick: Other
+    name:
+      if:
+        - choice:
+            when: <<gender=='Male'>>
+            pick:
+              fake: first_name_male
+
+        - choice:
+            when: <<gender=='Female'>>
+            pick:
+              fake: first_name_female
+
+        - choice:
+            pick:
+              fake: first_name

--- a/tests/test_restartability.py
+++ b/tests/test_restartability.py
@@ -39,3 +39,18 @@ class TestRestart(unittest.TestCase):
         )
 
         assert write_row.mock_calls[-1][1][1]["id"] == 10
+
+    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
+    def test_faker_dates_work(self, write_row):
+        yaml = """
+            - object: foo
+              count: 50
+              fields:
+                a_date:
+                    date_between:
+                        start_date: -30d
+                        end_date: +180d
+            """
+        continuation_file = StringIO()
+        generate(StringIO(yaml), generate_continuation_file=continuation_file)
+        assert "a_date" in continuation_file.getvalue()


### PR DESCRIPTION
Faker and YAML are not compatible in some way that mysteriously only seems to be triggered (n this code base, at least) in Python 3.8.

I haven't had a chance to debug my tox situation in Snowfakery but running manually on my computer it seems to work in all 3 relevant Python versions.

`$ .tox/py36/bin/python -m pytest && .tox/py37/bin/python -m pytest &&  .tox/py38/bin/python -m pytest && echo success`

...

`success`

Although I won't generally bump the version number in feature branches, I do need to deploy this fix to unblock the CCI PR, so I'll do a release as soon as it is merged.