### PR TITLE
Feature/output folder

### DIFF
--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -129,7 +129,7 @@ def generate_cli(
         * JSON file (--output_format=json --output-file=foo.json)
         * diagram file (--output_format=png --output-file=foo.png)
         * a database identified by --dburl (e.g. --dburl sqlite:////tmp/foo.db)
-        * or to a directory as a set of CSV files (--dburl csvfile:///directory/)
+        * or to a directory as a set of CSV files (--output-format=csv --output-folder=csvfiles)
 
     Diagram output depends on the installation of pygraphviz ("pip install pygraphviz")
     """

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -397,8 +397,6 @@ class ImageOutputStream(GraphvizOutputStream):
         super().__init__(path)
 
     def close(self) -> None:
-        if isinstance(self.path, Path):
-            self.path = str()
         self.G.draw(path=self.stream, prog="dot", format=self.format)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,6 +273,48 @@ class TestGenerateFromCLI:
 
         assert "Usage:" in capsys.readouterr().err
 
+    def test_output_folder(self):
+        with TemporaryDirectory() as tempdir:
+            generate_cli.main(
+                [
+                    str(sample_yaml),
+                    "--output-folder",
+                    tempdir,
+                    "--output-file",
+                    "foo.json",
+                ],
+                standalone_mode=False,
+            )
+            assert isinstance(json.load(Path(tempdir, "foo.json").open()), list)
+
+    def test_output_folder__csv(self):
+        with TemporaryDirectory() as tempdir:
+            generate_cli.main(
+                [
+                    str(sample_yaml),
+                    "--output-folder",
+                    tempdir,
+                    "--output-format",
+                    "csv",
+                ],
+                standalone_mode=False,
+            )
+            assert Path(tempdir, "Account.csv").exists()
+
+    def test_output_folder__csv_new_folder(self):
+        with TemporaryDirectory() as tempdir:
+            generate_cli.main(
+                [
+                    str(sample_yaml),
+                    "--output-folder",
+                    Path(tempdir, "foo"),
+                    "--output-format",
+                    "csv",
+                ],
+                standalone_mode=False,
+            )
+            assert Path(tempdir, "foo", "Account.csv").exists()
+
 
 class TestCLIOptionChecking:
     def test_mapping_file_no_dburl(self):

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -234,7 +234,10 @@ class TestCSVOutputStream(unittest.TestCase, OutputCommonTests):
         with TemporaryDirectory() as t:
             output_stream = CSVOutputStream(Path(t) / "csvoutput")
             generate(StringIO(yaml), {}, output_stream)
-            output_stream.close()
+            messages = output_stream.close()
+            assert "foo.csv" in messages[0]
+            assert "bar.csv" in messages[1]
+            assert "csvw" in messages[2]
             assert (Path(t) / "csvoutput" / "foo.csv").exists()
             with open(Path(t) / "csvoutput" / "csvw_metadata.json") as f:
                 metadata = json.load(f)

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -204,7 +204,7 @@ class TestJSONOutputStream(unittest.TestCase, OutputCommonTests):
 class TestCSVOutputStream(unittest.TestCase, OutputCommonTests):
     def do_output(self, yaml):
         with TemporaryDirectory() as t:
-            output_stream = CSVOutputStream(f"csv://{t}/csvoutput")
+            output_stream = CSVOutputStream(Path(t) / "csvoutput")
             results = generate(StringIO(yaml), {}, output_stream)
             output_stream.close()
             table_names = results.tables.keys()
@@ -232,7 +232,7 @@ class TestCSVOutputStream(unittest.TestCase, OutputCommonTests):
             bard: 4
         """
         with TemporaryDirectory() as t:
-            output_stream = CSVOutputStream(f"csv://{t}/csvoutput")
+            output_stream = CSVOutputStream(Path(t) / "csvoutput")
             generate(StringIO(yaml), {}, output_stream)
             output_stream.close()
             assert (Path(t) / "csvoutput" / "foo.csv").exists()
@@ -242,14 +242,3 @@ class TestCSVOutputStream(unittest.TestCase, OutputCommonTests):
                     "foo.csv",
                     "bar.csv",
                 }
-
-    def test_from_cli(self):
-        with TemporaryDirectory() as t:
-            generate_cli.main(
-                [str(sample_yaml), "--dburl", f"csvfile://{t}/csvoutput"],
-                standalone_mode=False,
-            )
-            assert (Path(t) / "csvoutput" / "Account.csv").exists()
-            with open(Path(t) / "csvoutput" / "csvw_metadata.json") as f:
-                metadata = json.load(f)
-                assert {table["url"] for table in metadata["tables"]} == {"Account.csv"}


### PR DESCRIPTION
Add a new CLI option called output-folder which determines where the output goes. Defaults to "."

Use this to drive CSV folder selection instead of the csvfile:/// convention which was confusing and broken on Windows.
