### PR TITLE
Last change needed to be Windows compatible

### DIFF
--- a/tests/test_with_cci.py
+++ b/tests/test_with_cci.py
@@ -34,7 +34,7 @@ class Test_CLI_CCI(unittest.TestCase):
             )
 
             engine = create_engine(url)
-            connection = engine.connect()
-            result = list(connection.execute("select * from Account"))
-            assert result[0]["id"] == 1
-            assert result[0]["BillingCountry"] == "Canada"
+            with engine.connect() as connection:
+                result = list(connection.execute("select * from Account"))
+                assert result[0]["id"] == 1
+                assert result[0]["BillingCountry"] == "Canada"


### PR DESCRIPTION
Forgot one Windows incompatibility because it is gated by CCI availability. (in other words it is only triggered on the part of the matrix which is CCi-available/running on Windows)