### PR TITLE
Pin minimum requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 with open("requirements.txt") as requirements_file:
-    requirements = [req.split("#")[0].strip() for req in requirements_file]
+    requirements = [req.replace("==", ">=").strip() for req in requirements_file]
 
 with open("requirements_dev.txt") as dev_requirements_file:
     test_requirements = [


### PR DESCRIPTION
This is intended to make it so that we don't have to make a new snowfakery release every time CumulusCI updates its required version of one of the dependencies it shares with snowfakery.