### PR TITLE
Add support for Salesforce record types to Snowfakery

### DIFF
--- a/snowfakery/data_generator.py
+++ b/snowfakery/data_generator.py
@@ -35,11 +35,11 @@ class ExecutionSummary:
 
     def __init__(self, parse_results, runtime_results):
         self.tables = parse_results.tables
-        self.dom = parse_results.templates
+        self.templates = parse_results.templates
         self.intertable_dependencies = runtime_results.intertable_dependencies
 
     def summarize_for_debugging(self):
-        return self.intertable_dependencies, self.dom
+        return self.intertable_dependencies, self.templates
 
 
 def merge_options(option_definitions: List, user_options: Mapping) -> Tuple[Dict, set]:

--- a/snowfakery/data_generator_runtime_dom.py
+++ b/snowfakery/data_generator_runtime_dom.py
@@ -131,9 +131,6 @@ class ObjectTemplate:
         self._generate_fields(context, row)
 
         try:
-            # both of these lines loop over the fields so they could maybe
-            # be combined but it kind of messes with the modularity of the
-            # code.
             self.register_row_intertable_references(row, context)
             if not self.tablename.startswith("__"):
                 storage.write_row(self.tablename, row)

--- a/snowfakery/generate_mapping_from_factory.py
+++ b/snowfakery/generate_mapping_from_factory.py
@@ -66,7 +66,7 @@ def generate_record_type_pseudo_tables(summary):
                     Dependency(record_type_name, *dependency[1:])
                 )
 
-        # the record type field isn't halpful for the TableInfo of the real table anymore
+        # the record type field isn't helpful for the TableInfo of the real table anymore
         # need a conditional here to ensure its only deleted once
         if real_table.fields.get("RecordType"):
             del real_table.fields["RecordType"]

--- a/snowfakery/generate_mapping_from_factory.py
+++ b/snowfakery/generate_mapping_from_factory.py
@@ -60,7 +60,7 @@ def generate_record_type_pseudo_tables(summary):
         record_type_pseudo_table.record_type = record_type_name
 
         # copy over the dependencies from the real table
-        for dependency in list(summary.intertable_dependencies):
+        for dependency in summary.intertable_dependencies.copy():
             if dependency.table_name_from == real_table_name:
                 summary.intertable_dependencies.add(
                     Dependency(record_type_name, *dependency[1:])

--- a/snowfakery/parse_factory_yaml.py
+++ b/snowfakery/parse_factory_yaml.py
@@ -46,7 +46,8 @@ class TableInfo:
     unifies what we know about it.
     """
 
-    def __init__(self):
+    def __init__(self, name):
+        self.name = name
         self.fields = {}
         self.friends = {}
         self._templates = []
@@ -68,7 +69,7 @@ class ParseContext:
         self.plugins = []
         self.line_numbers = {}
         self.options = []
-        self.object_infos = {}
+        self.table_infos = {}
 
     def line_num(self, obj=None) -> Dict:
         if not obj:
@@ -112,8 +113,10 @@ class ParseContext:
         We register templates so we can get a list of all fields that can
         be generated. This can be used to create a dynamic schema.
         """
-        table_info = self.object_infos.get(template.tablename, None) or TableInfo()
-        self.object_infos[template.tablename] = table_info
+        table_info = self.table_infos.get(template.tablename, None) or TableInfo(
+            template.tablename
+        )
+        self.table_infos[template.tablename] = table_info
         table_info.register(template)
 
 
@@ -492,10 +495,10 @@ def parse_factory(stream: IO[str]) -> ParseResult:
     context = ParseContext()
     objects = parse_file(stream, context)
     templates = parse_object_template_list(objects, context)
-    tables = context.object_infos
+    tables = context.table_infos
     tables = {
         name: value
-        for name, value in context.object_infos.items()
+        for name, value in context.table_infos.items()
         if not name.startswith("__")
     }
 

--- a/tests/cci/record_types.yml
+++ b/tests/cci/record_types.yml
@@ -1,0 +1,30 @@
+- object: Account
+  fields:
+     name: Bluth Family
+     RecordType: Household
+     primary_contact:
+        - object: Contact
+          nickname: Michael
+          fields:
+            name: Michael Bluth
+- object: Account
+  fields:
+     name: Bluth Corporation
+     primary_contact:
+        reference: Michael
+     RecordType: Organization
+- object: Account
+  fields:
+     name: The Windors
+     primary_contact:
+      - object: Contact
+        nickname: Liz
+        fields: 
+          name: The Queen
+     RecordType: Household
+- object: Account
+  fields:
+     name: The Firm
+     primary_contact:
+        reference: Liz
+     RecordType: Organization


### PR DESCRIPTION
Renamed some internal attributes for clarity in data_generator.py and parse_factory_yaml.py

Delete some confusing commentary in data_generator_dom.py.

Add record_type support to generate_mapping_from_factory.py

Capture the table name on TableInfo objects so that when we clone them for record type objects, we still know what table they came from.

Add tests and a test recipe.
