### PR TITLE
Cache parsed dates

### DIFF
--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -1,4 +1,5 @@
 import random
+from functools import lru_cache
 from datetime import date, datetime
 import dateutil.parser
 from ast import literal_eval
@@ -108,6 +109,7 @@ def choice_wrapper(
     return probability or when, pick
 
 
+@lru_cache(maxsize=512)
 def parse_date(d: Union[str, datetime, date]) -> Optional[Union[datetime, date]]:
     if isinstance(d, (datetime, date)):
         return d


### PR DESCRIPTION
Date parsing takes a lot of time and we only ever parsing dates from the actual recipe, never from Faker. Since the recipe is relatively small, we might as well just cache the result of parsing the dates.