### PR TITLE
Use plugin architecture for builtin functions

### DIFF
--- a/snowfakery/__init__.py
+++ b/snowfakery/__init__.py
@@ -1,1 +1,1 @@
-from .plugins import SnowfakeryPlugin  # noqa
+from .plugins import SnowfakeryPlugin, lazy  # noqa

--- a/snowfakery/plugins.py
+++ b/snowfakery/plugins.py
@@ -1,3 +1,6 @@
+from typing import Any, Callable
+
+
 class SnowfakeryPlugin:
     """Base class for all plugins.
 
@@ -60,3 +63,12 @@ class PluginContext:
         return self.interpreter.current_context.context_vars(
             self.plugin.__class__.__name__
         )
+
+    def evaluate(self, field_definition):
+        return field_definition.render(self.interpreter.current_context)
+
+
+def lazy(func: Any) -> Callable:
+    """A lazy function is one that expects its arguments to be unparsed"""
+    func.lazy = True
+    return func

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -4,15 +4,15 @@ from datetime import date, datetime
 import dateutil.parser
 from ast import literal_eval
 
-from typing import Callable, Any, Optional, Union, List, Tuple
+from typing import Optional, Union, List, Tuple
 
 from faker import Faker
 
 from .data_gen_exceptions import DataGenError
 
 import snowfakery.data_generator_runtime  # noqa
+from snowfakery.plugins import SnowfakeryPlugin, PluginContext, lazy
 
-RuntimeContext = "snowfakery.data_generator_runtime.RuntimeContext"
 FieldDefinition = "snowfakery.data_generator_runtime_dom.FieldDefinition"
 ObjectRow = "snowfakery.data_generator_runtime.ObjectRow"
 
@@ -22,18 +22,7 @@ fake = Faker()
 # Python 3.6 is out of the support matrix.
 
 
-def lazy(func: Any) -> Callable:
-    """A lazy function is one that expects its arguments to be unparsed"""
-    func.lazy = True
-    return func
-
-
-def random_number(context: RuntimeContext, min: int, max: int) -> int:
-    """Pick a random number between min and max like Python's randint."""
-    return random.randint(min, max)
-
-
-def parse_weight_str(context: RuntimeContext, weight_value) -> int:
+def parse_weight_str(context: PluginContext, weight_value) -> int:
     """For constructs like:
 
     - choice:
@@ -42,7 +31,7 @@ def parse_weight_str(context: RuntimeContext, weight_value) -> int:
 
     Render and convert the 60% to just 60.
     """
-    weight_str = weight_value.render(context)
+    weight_str = context.evaluate(weight_value)
     if isinstance(weight_str, str):
         weight_str = weight_str.rstrip("%")
     return int(weight_str)
@@ -55,60 +44,6 @@ def weighted_choice(choices: List[Tuple[int, object]]):
     return random.choices(options, weights, k=1)[0]
 
 
-@lazy
-def random_choice(context: RuntimeContext, *choices):
-    """Template helper for random choices.
-
-    Supports structures like this:
-
-    random_choice:
-        - a
-        - b
-        - <<c>>
-
-    Or like this:
-
-    random_choice:
-        - choice:
-            pick: A
-            probability: 50%
-        - choice:
-            pick: A
-            probability: 50%
-
-    Probabilities are really just weights and don't need to
-    add up to 100.
-
-    Pick-items can have arbitrary internal complexity.
-
-    Pick-items are lazily evaluated.
-    """
-    if not choices:
-        raise ValueError("No choices supplied!")
-
-    if getattr(choices[0], "function_name", None) == "choice":
-        choices = [choice.render(context) for choice in choices]
-        rc = weighted_choice(choices)
-    else:
-        rc = random.choice(choices)
-    if hasattr(rc, "render"):
-        rc = rc.render(context)
-    return rc
-
-
-@lazy
-def choice_wrapper(
-    context: RuntimeContext,
-    pick,
-    probability: FieldDefinition = None,
-    when: FieldDefinition = None,
-):
-    """Supports the choice: sub-items used in `random_choice` or `if`"""
-    if probability:
-        probability = parse_weight_str(context, probability)
-    return probability or when, pick
-
-
 @lru_cache(maxsize=512)
 def parse_date(d: Union[str, datetime, date]) -> Optional[Union[datetime, date]]:
     if isinstance(d, (datetime, date)):
@@ -119,113 +54,162 @@ def parse_date(d: Union[str, datetime, date]) -> Optional[Union[datetime, date]]
         pass
 
 
-def date_(
-    context: RuntimeContext,
-    *,
-    year: Union[str, int],
-    month: Union[str, int],
-    day: Union[str, int],
-):
-    """A YAML-embeddable function to construct a date from strings or integers"""
-    return date(year, month, day)
-
-
-def datetime_(
-    context: RuntimeContext,
-    *,
-    year: Union[str, int],
-    month: Union[str, int],
-    day: Union[str, int],
-    hour=0,
-    minute=0,
-    second=0,
-    microsecond=0,
-):
-    """A YAML-embeddable function to construct a datetime from strings or integers"""
-    return datetime(year, month, day, hour, minute, second, microsecond)
-
-
-def date_between(context: RuntimeContext, start_date, end_date):
-    """A YAML-embeddable function to pick a date between two ranges"""
-    start_date = parse_date(start_date) or start_date
-    end_date = parse_date(end_date) or end_date
-    try:
-        return fake.date_between(start_date, end_date)
-    except ValueError as e:
-        if "empty range" not in str(e):
-            raise
-    # swallow empty range errors per Python conventions
-
-
-def reference(context: RuntimeContext, x: Union[ObjectRow, str]):
-    """YAML-embeddable function to Reference another object."""
-    if hasattr(x, "id"):  # reference to an object with an id
-        target = x
-    elif isinstance(x, str):  # name of an object
-        obj = context.field_vars()[x]
-        if not getattr(obj, "id"):
-            raise DataGenError(f"Reference to incorrect object type {obj}", None, None)
-        target = obj
-    else:
-        raise DataGenError(
-            f"Can't get reference to object of type {type(x)}: {x}", None, None
-        )
-
-    return target
-
-
-def render_boolean(context: RuntimeContext, value: FieldDefinition) -> bool:
-    val = value.render(context)
+def render_boolean(context: PluginContext, value: FieldDefinition) -> bool:
+    val = context.evaluate(value)
     if isinstance(val, str):
         val = literal_eval(val)
 
     return bool(val)
 
 
-@lazy
-def if_(context: RuntimeContext, *choices: FieldDefinition):
-    """Template helper for conditional choices.
+class StandardFuncs(SnowfakeryPlugin):
+    class Functions:
+        int = int
 
-    Supports structures like this:
+        def date(
+            self,
+            *,
+            year: Union[str, int],
+            month: Union[str, int],
+            day: Union[str, int],
+        ):
+            """A YAML-embeddable function to construct a date from strings or integers"""
+            return date(year, month, day)
 
-    if:
-        - choice:
-            when: <<something>>
-            pick: A
-        - choice:
-            when: <<something>>
-            pick: B
+        def datetime(
+            self,
+            *,
+            year: Union[str, int],
+            month: Union[str, int],
+            day: Union[str, int],
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        ):
+            """A YAML-embeddable function to construct a datetime from strings or integers"""
+            return datetime(year, month, day, hour, minute, second, microsecond)
 
-    Pick-items can have arbitrary internal complexity.
+        def date_between(self, *, start_date, end_date):
+            """A YAML-embeddable function to pick a date between two ranges"""
+            start_date = parse_date(start_date) or start_date
+            end_date = parse_date(end_date) or end_date
+            try:
+                return fake.date_between(start_date, end_date)
+            except ValueError as e:
+                if "empty range" not in str(e):
+                    raise
+            # swallow empty range errors per Python conventions
 
-    Pick-items are lazily evaluated.
-    """
-    if not choices:
-        raise ValueError("No choices supplied!")
+        def random_number(self, min: int, max: int) -> int:
+            """Pick a random number between min and max like Python's randint."""
+            return random.randint(min, max)
 
-    choices = [choice.render(context) for choice in choices]
-    for when, choice in choices[:-1]:
-        if when is None:
-            raise SyntaxError(
-                "Every choice except the last one should have a when-clause"
+        def reference(self, x: Union[ObjectRow, str]):
+            """YAML-embeddable function to Reference another object."""
+            if hasattr(x, "id"):  # reference to an object with an id
+                target = x
+            elif isinstance(x, str):  # name of an object
+                obj = self.context.field_vars()[x]
+                if not getattr(obj, "id"):
+                    raise DataGenError(
+                        f"Reference to incorrect object type {obj}", None, None
+                    )
+                target = obj
+            else:
+                raise DataGenError(
+                    f"Can't get reference to object of type {type(x)}: {x}", None, None
+                )
+
+            return target
+
+        @lazy
+        def random_choice(self, *choices):
+            """Template helper for random choices.
+
+            Supports structures like this:
+
+            random_choice:
+                - a
+                - b
+                - <<c>>
+
+            Or like this:
+
+            random_choice:
+                - choice:
+                    pick: A
+                    probability: 50%
+                - choice:
+                    pick: A
+                    probability: 50%
+
+            Probabilities are really just weights and don't need to
+            add up to 100.
+
+            Pick-items can have arbitrary internal complexity.
+
+            Pick-items are lazily evaluated.
+            """
+            if not choices:
+                raise ValueError("No choices supplied!")
+
+            if getattr(choices[0], "function_name", None) == "choice":
+                choices = [self.context.evaluate(choice) for choice in choices]
+                rc = weighted_choice(choices)
+            else:
+                rc = random.choice(choices)
+            if hasattr(rc, "render"):
+                rc = self.context.evaluate(rc)
+            return rc
+
+        @lazy
+        def choice(
+            self,
+            pick,
+            probability: FieldDefinition = None,
+            when: FieldDefinition = None,
+        ):
+            """Supports the choice: sub-items used in `random_choice` or `if`"""
+            if probability:
+                probability = parse_weight_str(self.context, probability)
+            return probability or when, pick
+
+        @lazy
+        def if_(self, *choices: FieldDefinition):
+            """Template helper for conditional choices.
+
+            Supports structures like this:
+
+            if:
+                - choice:
+                    when: <<something>>
+                    pick: A
+                - choice:
+                    when: <<something>>
+                    pick: B
+
+            Pick-items can have arbitrary internal complexity.
+
+            Pick-items are lazily evaluated.
+            """
+            if not choices:
+                raise ValueError("No choices supplied!")
+
+            choices = [self.context.evaluate(choice) for choice in choices]
+            for when, choice in choices[:-1]:
+                if when is None:
+                    raise SyntaxError(
+                        "Every choice except the last one should have a when-clause"
+                    )
+            true_choices = (
+                choice
+                for when, choice in choices
+                if when and render_boolean(self.context, when)
             )
-    true_choices = (
-        choice for when, choice in choices if when and render_boolean(context, when)
-    )
-    rc = next(true_choices, choices[-1][-1])  # default to last choice
-    if hasattr(rc, "render"):
-        rc = rc.render(context)
-    return rc
+            rc = next(true_choices, choices[-1][-1])  # default to last choice
+            if hasattr(rc, "render"):
+                rc = self.context.evaluate(rc)
+            return rc
 
-
-template_funcs = {
-    "int": lambda context, number: int(number),
-    "choice": choice_wrapper,
-    "random_number": random_number,
-    "random_choice": random_choice,
-    "date_between": date_between,
-    "reference": reference,
-    "date": date_,
-    "datetime": datetime_,
-    "if": if_,
-}
+    setattr(Functions, "if", Functions.if_)

--- a/tests/test_custom_plugins_and_providers.py
+++ b/tests/test_custom_plugins_and_providers.py
@@ -2,7 +2,7 @@ from io import StringIO
 import math
 
 from snowfakery.data_generator import generate
-from snowfakery import SnowfakeryPlugin
+from snowfakery import SnowfakeryPlugin, lazy
 
 from unittest import mock
 import pytest
@@ -18,6 +18,16 @@ class SimpleTestPlugin(SnowfakeryPlugin):
     class Functions:
         def double(self, value):
             return value * 2
+
+
+class DoubleVisionPlugin(SnowfakeryPlugin):
+    class Functions:
+        @lazy
+        def do_it_twice(self, value):
+            "Evaluates its argument twice into a string"
+            rc = f"{self.context.evaluate(value)} : {self.context.evaluate(value)}"
+
+            return rc
 
 
 class TestCustomFakerProvider:
@@ -118,6 +128,12 @@ class PluginThatNeedsState(SnowfakeryPlugin):
             context_vars["object_path"] = new_value
             return new_value
 
+        def count(self):
+            context_vars = self.context.context_vars()
+            context_vars.setdefault("count", 0)
+            context_vars["count"] += 1
+            return context_vars["count"]
+
 
 class TestContextVars:
     @mock.patch(write_row_path)
@@ -138,3 +154,22 @@ class TestContextVars:
 
         assert row_values(write_row, 0, "path") == "ROOT.OBJ1.OBJ2"
         assert row_values(write_row, 1, "path") == "ROOT.OBJ1"
+
+    @mock.patch(write_row_path)
+    def test_lazy_with_context(self, write_row):
+        yaml = """
+        - plugin: tests.test_custom_plugins_and_providers.DoubleVisionPlugin
+        - plugin: tests.test_custom_plugins_and_providers.PluginThatNeedsState
+        - object: OBJ
+          fields:
+            some_value:
+                - DoubleVisionPlugin.do_it_twice:
+                    - abc
+            some_value_2:
+                - DoubleVisionPlugin.do_it_twice:
+                    - <<PluginThatNeedsState.count()>>
+        """
+        generate(StringIO(yaml), {})
+
+        assert row_values(write_row, 0, "some_value") == "abc : abc"
+        assert row_values(write_row, 0, "some_value_2") == "1 : 2"

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -71,6 +71,22 @@ class TestTemplateFuncs(unittest.TestCase):
         # TODO CHECK MORE
 
     @mock.patch(write_row_path)
+    def test_conditional_is_lazy(self, write_row):
+        yaml = """
+        - object : A
+          fields:
+            a:
+                if:
+                    - choice:
+                        when: False
+                        pick: <<should_not_be_evaluated>>
+                    - choice:
+                        pick: BBB
+        """
+        generate(StringIO(yaml), {}, None)
+        assert write_row.mock_calls == [mock.call("A", {"id": 1, "a": "BBB"})]
+
+    @mock.patch(write_row_path)
     def test_conditional(self, write_row):
         yaml = """
         - object : A


### PR DESCRIPTION
Instead of having a different way of pulling standard library functions into the interpreter, they are now a plugin like any other one. The only difference is the unavoidable one, which is that they are promoted to the top namespace rather than being nested in a plugin namespace.

In order to allow this, I exposed the @lazy decorator to plugin authors and documented it in the Quip doc.

There was some quite inefficient code related to the old way of doing the standard library (injecting runtime context over and over, instead of looking it up lazily), so this should result in a modest performance improvement.