### PR TITLE
Fix duplicate table issues similar to CCI

### DIFF
--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -291,7 +291,13 @@ class SqlOutputStream(OutputStream):
             with self.engine.connect() as connection:
                 for mapping in self.mappings.values():
                     # caller may have already created the tables
-                    if not self.engine.dialect.has_table(connection, mapping["table"]):
+                    # or the table may be defined in two different
+                    # mappings
+                    tablename = mapping["table"]
+                    if (
+                        not self.engine.dialect.has_table(connection, tablename)
+                        and tablename not in self.metadata.tables
+                    ):
                         create_table_from_mapping(mapping, self.metadata)
         else:
             create_tables_from_inferred_fields(

--- a/tests/mapping_vanilla_sf.yml
+++ b/tests/mapping_vanilla_sf.yml
@@ -65,3 +65,21 @@ Insert Opportunities:
       table: Account
     ContactId:
       table: Contact
+Insert Opportunities Again:
+  sf_object: Opportunity
+  action: insert
+  table: Opportunity
+  fields:
+    Name: Name
+    StageName: StageName
+    CloseDate: CloseDate
+    ContactId: ContactId
+    AccountId: AccountId
+    Amount: Amount
+  filter:
+    StageName = 'Impossible'
+  lookups:
+    AccountId:
+      table: Account
+    ContactId:
+      table: Contact


### PR DESCRIPTION
This code should eventually be replaced by code in CumulusCI, but as long as it is here, it should be correct.

When I wrote it, I didn't know or forgot that two different mapping steps can generate the same table.

It isn't smart about merging columns from multiple steps, but neither is CCI.