### PR TITLE
Suppress traceback for YAML errors

### DIFF
--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -175,10 +175,7 @@ def generate_cli(
                 raise e
             else:
                 click.echo("")
-                click.echo(
-                    "An error occurred. If you would like to see a Python traceback, "
-                    "use the --debug-internals option."
-                )
+                click.echo(e.prefix)
                 raise click.ClickException(str(e)) from e
 
 

--- a/snowfakery/data_gen_exceptions.py
+++ b/snowfakery/data_gen_exceptions.py
@@ -1,4 +1,9 @@
 class DataGenError(Exception):
+    prefix = (
+        "An error occurred. If you would like to see a Python traceback, "
+        "use the --debug-internals option."
+    )
+
     def __init__(self, message, filename, line_num):
         self.message = message
         self.filename = filename
@@ -12,6 +17,18 @@ class DataGenError(Exception):
 
 
 class DataGenSyntaxError(DataGenError):
+    pass
+
+
+class DataGenYamlSyntaxError(DataGenSyntaxError):
+    prefix = (
+        "There is a problem with your YAML file.\n"
+        + "Consider installing a YAML Validator Plugin for your editor.\n"
+        + "For example, if you use VSCode, "
+        + "https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml \n"
+        + "Or: https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml \n"
+        + "The error is:\n"
+    )
     pass
 
 

--- a/snowfakery/parse_recipe_yaml.py
+++ b/snowfakery/parse_recipe_yaml.py
@@ -9,6 +9,7 @@ from typing import IO, List, Dict, Union, Tuple, Any, Iterable, Sequence, Mappin
 import yaml
 from yaml.composer import Composer
 from yaml.constructor import SafeConstructor
+from yaml.error import YAMLError
 
 from .data_generator_runtime_object_model import (
     ObjectTemplate,
@@ -475,7 +476,14 @@ def parse_file(stream: IO[str], context: ParseContext) -> List[Dict]:
         path = Path(fsdecode(stream.name)).absolute()
     else:
         path = Path("<stream>")
-    data, line_numbers = yaml_safe_load_with_line_numbers(stream, str(path))
+    try:
+        data, line_numbers = yaml_safe_load_with_line_numbers(stream, str(path))
+    except YAMLError as y:
+        raise DataGenSyntaxError(
+            f"There is a problem with your yaml file:\n{y}",
+            str(path),
+            y.problem_mark.line,
+        )
     context.line_numbers.update(line_numbers)
 
     if not isinstance(data, list):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -89,3 +89,12 @@ class TestErrors(unittest.TestCase):
             generate(StringIO(yaml))
         assert "Cannot evaluate function" in str(e.exception)
         assert ":6" in str(e.exception)
+
+    def test_yaml_error(self):
+        yaml = """
+        - object: B                             #2
+            velcro: C                             #3
+        """
+        with self.assertRaises(DataGenSyntaxError) as e:
+            generate(StringIO(yaml), {}, None)
+        assert str(e.exception)[-2:] == ":2"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -97,4 +97,4 @@ class TestErrors(unittest.TestCase):
         """
         with self.assertRaises(DataGenSyntaxError) as e:
             generate(StringIO(yaml), {}, None)
-        assert str(e.exception)[-2:] == ":2"
+        assert str(e.exception)[-2:] == ":3"

--- a/tests/test_parse_recipe_yaml_internals.py
+++ b/tests/test_parse_recipe_yaml_internals.py
@@ -7,9 +7,9 @@ from snowfakery.parse_recipe_yaml import (
     categorize_top_level_objects,
     ParseContext,
     LineTracker,
-    DataGenError,
     parse_file,
 )
+from snowfakery.data_gen_exceptions import DataGenError
 from tempfile import TemporaryDirectory
 
 linenum = {"__line__": LineTracker("f", 5)}


### PR DESCRIPTION
Previously if the user had errors in their YAML file, they would see a Python traceback. Now they will see just a short summary of the error without the traceback.