### PR TITLE
Allow forward references to nicknames.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -399,7 +399,7 @@ Fields can refer to functions which randomize, compute or look up data. We can d
 
 ### Reference
 
-This function allows you to look up a previously created row (object) and make a reference to it.
+This function allows you to look up another row (object) and make a reference to it.
 
 ```yaml
 - object: Animal
@@ -410,9 +410,22 @@ This function allows you to look up a previously created row (object) and make a
       reference: Person
 ```
 
-The reference function looks for an ancestor object by table name (`Person`, in this example) or a previously created nicknamed object by `nickname`.
+The reference function looks for another object by table name (`Person`, in this example) or a nicknamed object by `nickname`.
 
-### `random_choice`
+If an object was created earlier in the recipe, and it has the appropriate
+nickname or tablename, that object is the target reference.
+
+Otherwise, the reference can be to an object that has not been created yet. Snowfakery will generate an ID for the object so that the current row can be generated. No other properties of the other object can be referred to, because
+it does not exist yet.
+
+Snowfakery (and CumulusCI) allow one to loop over a recipe many times to
+generate multiple rows. In this case, references are always to objects
+created within the current "batch" of a recipe and never to a previous
+batch with only one exception: objects marked 'just_once' are always
+created only in the first run and references to them are to the
+objects created in that first batch.
+
+#### `random_choice`
 
 Function to choose an option randomly from a list:
 

--- a/snowfakery/data_gen_exceptions.py
+++ b/snowfakery/data_gen_exceptions.py
@@ -13,7 +13,13 @@ class DataGenError(Exception):
         super().__init__(self.message)
 
     def __str__(self):
-        return f"{self.message}\n near {self.filename}:{self.line_num}"
+        if self.line_num:
+            location = f"\n near {self.filename}:{self.line_num}"
+        elif self.filename:
+            location = f"\n in {self.filename}"
+        else:
+            location = ""
+        return f"{self.message}{location}"
 
 
 class DataGenSyntaxError(DataGenError):

--- a/snowfakery/data_generator.py
+++ b/snowfakery/data_generator.py
@@ -10,6 +10,7 @@ from .data_gen_exceptions import DataGenNameError
 from .output_streams import DebugOutputStream, OutputStream
 from .parse_recipe_yaml import parse_recipe
 from .data_generator_runtime import output_batches, StoppingCriteria, Globals
+from .data_gen_exceptions import DataGenError
 from . import SnowfakeryPlugin
 
 
@@ -144,17 +145,24 @@ def generate(
 
     faker_providers, snowfakery_plugins = process_plugins(parse_result.plugins)
 
-    # now do the output
-    runtime_context = output_batches(
-        output_stream,
-        parse_result.templates,
-        options,
-        stopping_criteria=stopping_criteria,
-        continuation_data=continuation_data,
-        tables=parse_result.tables,
-        snowfakery_plugins=snowfakery_plugins,
-        faker_providers=faker_providers,
-    )
+    try:
+        # now do the output
+        runtime_context = output_batches(
+            output_stream,
+            parse_result.templates,
+            options,
+            stopping_criteria=stopping_criteria,
+            continuation_data=continuation_data,
+            tables=parse_result.tables,
+            snowfakery_plugins=snowfakery_plugins,
+            faker_providers=faker_providers,
+        )
+    except DataGenError as e:
+        if e.filename:
+            raise
+        else:
+            e.filename = getattr(open_yaml_file, "name", None)
+            raise
 
     if generate_continuation_file:
         safe_dump(runtime_context, generate_continuation_file)

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -372,7 +372,7 @@ class RuntimeContext:
 
     def check_if_finished(self):
         "Have we iterated over the script enough times?"
-        # TODO: check that every forward reference was resolved
+        # check that every forward reference was resolved
         self.interpreter.globals.check_slots_filled()
         return self.interpreter.finished_checker.check_if_finished(
             self.interpreter.globals.id_manager

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -328,7 +328,7 @@ class Interpreter:
 
         self.templates = templates
 
-    def loop_over_templates(self, runtimecontext, continuing):
+    def loop_over_templates_until_finished(self, runtimecontext, continuing):
         finished = False
         while not finished:
             self.loop_over_templates_once(runtimecontext, continuing)
@@ -579,7 +579,7 @@ def output_batches(
 
     runtimecontext = RuntimeContext(interpreter=interpreter)
     continuing = bool(continuation_data)
-    interpreter.loop_over_templates(runtimecontext, continuing)
+    interpreter.loop_over_templates_until_finished(runtimecontext, continuing)
     return interpreter.globals
 
 

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -156,8 +156,7 @@ class ObjectTemplate:
 
     def _check_type(self, field, generated_value, context: RuntimeContext):
         """Check the type of a field value"""
-        allowed_types = FieldValue
-        if not isinstance(generated_value, allowed_types.__args__):
+        if not isinstance(generated_value, FieldValue.__args__):
             raise DataGenValueError(
                 f"Field '{field.name}' generated unexpected object: {generated_value} {type(generated_value)}",
                 self.filename,

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -1,9 +1,13 @@
 from abc import abstractmethod, ABC
-from datetime import date, datetime
-from .data_generator_runtime import evaluate_function, ObjectRow, RuntimeContext
+from .data_generator_runtime import (
+    evaluate_function,
+    ObjectRow,
+    RuntimeContext,
+    FieldValue,
+    Scalar,
+)
 from contextlib import contextmanager
 from typing import Union, Dict, Sequence, Optional, cast
-from numbers import Number
 from .utils.template_utils import look_for_number
 
 import jinja2
@@ -18,8 +22,6 @@ from .data_gen_exceptions import (
 
 # objects that represent the hierarchy of a data generator.
 # roughly similar to the YAML structure but with domain-specific objects
-Scalar = Union[str, Number, date, datetime, None]
-FieldValue = Union[None, Scalar, ObjectRow, tuple]
 Definition = Union["ObjectTemplate", "SimpleValue", "StructuredValue"]
 
 
@@ -128,7 +130,8 @@ class ObjectTemplate:
 
     def _generate_row(self, storage, context: RuntimeContext, index: int) -> ObjectRow:
         """Generate an individual row"""
-        row = {"id": context.generate_id()}
+        id = context.generate_id(self.nickname)
+        row = {"id": id}
         sobj = ObjectRow(self.tablename, row, index)
 
         context.register_object(sobj, self.nickname)
@@ -153,8 +156,8 @@ class ObjectTemplate:
 
     def _check_type(self, field, generated_value, context: RuntimeContext):
         """Check the type of a field value"""
-        allowed_types = (int, str, bool, date, float, type(None), ObjectRow)
-        if not isinstance(generated_value, allowed_types):
+        allowed_types = FieldValue
+        if not isinstance(generated_value, allowed_types.__args__):
             raise DataGenValueError(
                 f"Field '{field.name}' generated unexpected object: {generated_value} {type(generated_value)}",
                 self.filename,

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -68,7 +68,7 @@ class OutputStream(ABC):
         sourcetable: str,
         fieldname: str,
         source_row_dict: Dict,
-        target_object_row: [ObjectRow, NicknameSlot],
+        target_object_row: Union[ObjectRow, NicknameSlot],
     ) -> Union[str, int]:
         return target_object_row.id
 
@@ -155,7 +155,7 @@ class DebugOutputStream(FileOutputStream):
         sourcetable: str,
         fieldname: str,
         source_row_dict: Dict,
-        target_object_row: [ObjectRow, NicknameSlot],
+        target_object_row: Union[ObjectRow, NicknameSlot],
     ) -> Union[str, int]:
         return f"{target_object_row._tablename}({target_object_row.id})"
 
@@ -354,7 +354,7 @@ class GraphvizOutputStream(FileOutputStream):
         sourcetable: str,
         fieldname: str,
         source_row_dict: Dict,
-        target_object_row: [ObjectRow, NicknameSlot],
+        target_object_row: Union[ObjectRow, NicknameSlot],
     ) -> Union[str, int]:
         source_node_name = self.generate_node_name(
             sourcetable, source_row_dict.get("name"), source_row_dict.get("id")

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -27,7 +27,7 @@ except (ImportError, ModuleNotFoundError) as e:
         raise exception
 
 
-from .data_generator_runtime import ObjectRow
+from .data_generator_runtime import ObjectRow, NicknameSlot
 from .parse_recipe_yaml import TableInfo
 
 
@@ -68,7 +68,7 @@ class OutputStream(ABC):
         sourcetable: str,
         fieldname: str,
         source_row_dict: Dict,
-        target_object_row: ObjectRow,
+        target_object_row: [ObjectRow, NicknameSlot],
     ) -> Union[str, int]:
         return target_object_row.id
 
@@ -79,7 +79,7 @@ class OutputStream(ABC):
         pass
 
     def cleanup(self, field_name, field_value, sourcetable, row):
-        if isinstance(field_value, ObjectRow):
+        if isinstance(field_value, (ObjectRow, NicknameSlot)):
             return self.flatten(sourcetable, field_name, row, field_value)
         else:
             encoder = self.encoders.get(type(field_value))
@@ -155,7 +155,7 @@ class DebugOutputStream(FileOutputStream):
         sourcetable: str,
         fieldname: str,
         source_row_dict: Dict,
-        target_object_row: ObjectRow,
+        target_object_row: [ObjectRow, NicknameSlot],
     ) -> Union[str, int]:
         return f"{target_object_row._tablename}({target_object_row.id})"
 
@@ -354,7 +354,7 @@ class GraphvizOutputStream(FileOutputStream):
         sourcetable: str,
         fieldname: str,
         source_row_dict: Dict,
-        target_object_row: ObjectRow,
+        target_object_row: [ObjectRow, NicknameSlot],
     ) -> Union[str, int]:
         source_node_name = self.generate_node_name(
             sourcetable, source_row_dict.get("name"), source_row_dict.get("id")

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -130,7 +130,9 @@ class StandardFuncs(SnowfakeryPlugin):
             if hasattr(x, "id"):  # reference to an object with an id
                 target = x
             elif isinstance(x, str):  # name of an object
-                obj = self.context.field_vars()[x]
+                obj = self.context.field_vars().get(x)
+                if not obj:
+                    raise DataGenError(f"Cannot find an object named {x}", None, None)
                 if not getattr(obj, "id"):
                     raise DataGenError(
                         f"Reference to incorrect object type {obj}", None, None

--- a/tests/broken_forward_reference.yml
+++ b/tests/broken_forward_reference.yml
@@ -1,0 +1,19 @@
+- object: A
+  fields:
+    B:
+      reference: Bob
+    C:
+      reference: John
+- object: B
+  nickname: Bob
+  fields:
+    A:
+      reference: A
+    D:
+      reference: Bill
+- object: C
+  nickname: John
+  count: 0
+- object: D
+  nickname: Bill
+  count: 0

--- a/tests/forward_reference.yml
+++ b/tests/forward_reference.yml
@@ -1,0 +1,9 @@
+- object: A
+  fields:
+    B:
+      reference: Bob
+- object: B
+  nickname: Bob
+  fields:
+    A:
+      reference: A

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -66,6 +66,7 @@ last_seen_obj_of_type:
     id: 41
   bar:
     id: 1000
+nicknames_and_tables: {}
                 """
         generate(
             StringIO(yaml),

--- a/tests/test_generate_mapping.py
+++ b/tests/test_generate_mapping.py
@@ -88,8 +88,9 @@ class TestGenerateMapping(unittest.TestCase):
                   reference:
                     alpha
               """
-        with self.assertRaises(DataGenError):
-            generate(StringIO(yaml), {}, None)
+        summary = generate(StringIO(yaml), {}, None)
+        mapping = mapping_from_recipe_templates(summary)
+        assert mapping
 
     def test_circular_table_reference(self):
         yaml = """

--- a/tests/test_generate_mapping.py
+++ b/tests/test_generate_mapping.py
@@ -73,7 +73,7 @@ class TestGenerateMapping(unittest.TestCase):
         assert mapping["Insert Referrer"]["fields"] == {"food": "food"}
         assert mapping["Insert Referrer"]["lookups"]["shrimpguy"]["table"] == "Target"
 
-    def test_forward_reference(self):
+    def test_forward_reference__nickname(self):
         yaml = """
             - object: A
               nickname: alpha

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -122,6 +122,26 @@ class TestReferences(unittest.TestCase):
         assert b_values["A"] == "A(1)"
 
     @mock.patch(write_row_path)
+    def test_forward_reference__tablename(self, write_row):
+        yaml = """
+            - object: A
+              fields:
+                B:
+                  reference:
+                    B
+            - object: B
+              fields:
+                A:
+                  reference:
+                    A
+              """
+        generate(StringIO(yaml), {}, None)
+        a_values = find_row("A", {}, write_row.mock_calls)
+        b_values = find_row("B", {}, write_row.mock_calls)
+        assert a_values["B"] == "B(1)"
+        assert b_values["A"] == "A(1)"
+
+    @mock.patch(write_row_path)
     def test_forward_reference_not_fulfilled(self, write_row):
         yaml = """
         - object: A
@@ -140,8 +160,26 @@ class TestReferences(unittest.TestCase):
 
         assert "Bob" in str(e.value)
 
+    def test_forward_reference_not_fulfilled__tablename(self):
+        yaml = """
+            - object: AAA
+              fields:
+                B:
+                  reference:
+                    BBB
+            - object: BBB
+              count: 0
+              fields:
+                A:
+                  reference:
+                    AAA
+              """
+        with pytest.raises(DataGenError) as e:
+            generate(StringIO(yaml), {}, None)
+        assert "BBB" in str(e.value)
+
     @mock.patch(write_row_path)
-    def test_forward_references_not_fulfilled(self, write_row):
+    def test_forward_references_not_fulfilled__nickname(self, write_row):
         yaml = """
         - object: A
           fields:

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,8 +1,12 @@
 from io import StringIO
 import unittest
 from unittest import mock
+
+import pytest
+
 from snowfakery.data_generator import generate
 from test_parse_samples import find_row
+from snowfakery.data_gen_exceptions import DataGenError
 
 simple_parent = """                     #1
 - object: A                             #2
@@ -96,3 +100,70 @@ class TestReferences(unittest.TestCase):
         id_a = a_values["id"]
         reference_a = b_values["A_ref"]
         assert f"A({id_a})" == reference_a
+
+    @mock.patch(write_row_path)
+    def test_forward_reference(self, write_row):
+        yaml = """
+        - object: A
+          fields:
+            B:
+              reference: Bob
+        - object: B
+          nickname: Bob
+          fields:
+            A:
+              reference: A
+        """
+        generate(StringIO(yaml), {}, None)
+
+        a_values = find_row("A", {}, write_row.mock_calls)
+        b_values = find_row("B", {}, write_row.mock_calls)
+        assert a_values["B"] == "B(1)"
+        assert b_values["A"] == "A(1)"
+
+    @mock.patch(write_row_path)
+    def test_forward_reference_not_fulfilled(self, write_row):
+        yaml = """
+        - object: A
+          fields:
+            B:
+              reference: Bob
+        - object: B
+          count: 0
+          nickname: Bob
+          fields:
+            A:
+              reference: A
+        """
+        with pytest.raises(DataGenError) as e:
+            generate(StringIO(yaml), {}, None)
+
+        assert "Bob" in str(e.value)
+
+    @mock.patch(write_row_path)
+    def test_forward_references_not_fulfilled(self, write_row):
+        yaml = """
+        - object: A
+          fields:
+            B:
+              reference: Bob
+            C:
+              reference: Bill
+        - object: B
+          count: 0
+          nickname: Bob
+          fields:
+            A:
+              reference: A
+        - object: B
+          count: 0
+          nickname: Bill
+          fields:
+            A:
+              reference: A
+        """
+        with pytest.raises(DataGenError) as e:
+            generate(StringIO(yaml), {}, None)
+
+        assert "Bob" in str(e.value)
+        assert "Bill" in str(e.value)


### PR DESCRIPTION
Support Snowfakery files like this:

```
- object: A
  fields:
    B:
      reference: Bob. # referenced before it is defined.
- object: B
  nickname: Bob
  fields:
    A:
      reference: A
```

A new object is created called EmptySlot which is allocated each time the recipe is instantiated, analogous to local variable slots in Python, or NamedTuple slots.

When a slot is allocated, it grabs a database ID just as an ObjectRow would. Then, when the object is created, it uses that ID.

If the ID is never used by any ObjectRow, that will cause a reportable error.

