### PR TITLE
Macros can include other macros

### DIFF
--- a/tests/macros-include-macros.yml
+++ b/tests/macros-include-macros.yml
@@ -1,0 +1,11 @@
+- macro: foo
+  fields:
+    foobar: FOOBAR
+
+- macro: bar
+  include: foo
+  fields:
+    barbar: BARBAR
+
+- object: Bar
+  include: bar

--- a/tests/macros-recurse-unbounded.yml
+++ b/tests/macros-recurse-unbounded.yml
@@ -1,0 +1,17 @@
+- macro: baz
+  include: bar
+  fields:
+    foobar: FOOBAR
+
+- macro: foo
+  include: baz
+  fields:
+    foobar: FOOBAR
+
+- macro: bar
+  include: foo
+  fields:
+    barbar: BARBAR
+
+- object: Bar
+  include: bar

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -77,3 +77,23 @@ class TestMacros(unittest.TestCase):
         assert write_row.mock_calls[0] == mock.call("foo", {"id": 1})
         assert write_row.mock_calls[1][1][0] == "bar"
         assert write_row.mock_calls[1][1][1]["myfoo"].id == 1
+
+    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
+    def test_macros_include_macros(self, write_row):
+        yaml = """
+        - macro: foo
+          fields:
+            foobar: FOOBAR
+
+        - macro: bar
+          include: foo
+          fields:
+            barbar: BARBAR
+
+        - object: Bar
+          include: bar
+        """
+        generate(StringIO(yaml))
+        assert write_row.mock_calls[0] == mock.call(
+            "Bar", {"id": 1, "barbar": "BARBAR", "foobar": "FOOBAR"}
+        )


### PR DESCRIPTION
For example:

```
- macro: foo
  fields:
    foobar: FOOBAR

- macro: bar
  include: foo
  fields:
    barbar: BARBAR

- object: Bar
  include: bar
```

Generates:

```
Bar(id=1, barbar=BARBAR, foobar=FOOBAR)
```
