### PR TITLE
PluginsResults with complex state state can implement "simplify"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1143,6 +1143,10 @@ expose a namespace that other code can access through dot-notation. PluginResult
 initialized with either a dict or an object that exposes the namespace through Python 
 getattr().
 
+If your plugin generates some special kind of data value which should be serializable
+as a primitive type (usually a string), subclass PluginResult and add a `simplify`
+method to your PluginResult. That method should return a Python primitive value.
+
 In the rare event that a plugin has a function which need its arguments to be passed to it unevaluated, for later (perhaps conditional) evaluation, you can use the `@snowfakery.lazy decorator`. Then you can evaluate the arguments with `self.context.evaluate()`. 
 
 For example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1188,7 +1188,7 @@ parameters lazily but doesn't care about the internals of the values
 because it just returns it to some parent context. In that case,
 use `context.evaluate_raw` instead of `context.evaluate`.
 
-## Using Snowfakery within CumulusC
+## Using Snowfakery within CumulusCI
 
 You can verify that a Snowfakery-compatible version of CumulusCI is installed like this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1183,6 +1183,11 @@ This would output an `OBJ` row with values:
   {'id': 1, 'some_value': 'abc : abc', 'some_value_2': '1 : 2'})
 ```
 
+Occasionally you might write a plugin which needs to evaluate its
+parameters lazily but doesn't care about the internals of the values
+because it just returns it to some parent context. In that case,
+use `context.evaluate_raw` instead of `context.evaluate`.
+
 ## Using Snowfakery within CumulusC
 
 You can verify that a Snowfakery-compatible version of CumulusCI is installed like this:

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date
 from contextlib import contextmanager
 from enum import Enum, auto
 
-from typing import Optional, Dict, List, Sequence, Mapping, NamedTuple, Union
-from numbers import Number
+from typing import Optional, Dict, List, Sequence, Mapping, NamedTuple
 
 import jinja2
 import yaml
@@ -625,9 +624,3 @@ def output_batches(
         continuing = bool(continuation_data)
         interpreter.loop_over_templates_until_finished(runtimecontext, continuing)
         return interpreter.globals
-
-
-Scalar = Union[str, Number, date, datetime, None]
-FieldValue = Union[
-    None, Scalar, ObjectRow, tuple, NicknameSlot, snowfakery.plugins.PluginResult
-]

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -3,8 +3,7 @@ from .data_generator_runtime import (
     evaluate_function,
     ObjectRow,
     RuntimeContext,
-    FieldValue,
-    Scalar,
+    NicknameSlot,
 )
 from contextlib import contextmanager
 from typing import Union, Dict, Sequence, Optional, cast
@@ -19,10 +18,12 @@ from .data_gen_exceptions import (
     DataGenValueError,
     fix_exception,
 )
+from .plugins import Scalar, PluginResult
 
 # objects that represent the hierarchy of a data generator.
 # roughly similar to the YAML structure but with domain-specific objects
 Definition = Union["ObjectTemplate", "SimpleValue", "StructuredValue"]
+FieldValue = Union[None, Scalar, ObjectRow, tuple, NicknameSlot, PluginResult]
 
 
 class FieldDefinition(ABC):

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -70,6 +70,11 @@ class OutputStream(ABC):
             return self.flatten(sourcetable, field_name, row, field_value)
         else:
             encoder = self.encoders.get(type(field_value))
+            if not encoder and hasattr(field_value, "simplify"):
+
+                def encoder(field_value):
+                    return field_value.simplify()
+
             if not encoder:
                 raise TypeError(
                     f"No encoder found for {type(field_value)} in {self.__class__.__name__} "

--- a/snowfakery/plugins.py
+++ b/snowfakery/plugins.py
@@ -81,9 +81,11 @@ class PluginContext:
         )
 
     def evaluate_raw(self, field_definition):
+        """Evaluate the contents of a field definition"""
         return field_definition.render(self.interpreter.current_context)
 
     def evaluate(self, field_definition):
+        """Evaluate the contents of a field definition and simplify to a primitive value."""
         rc = self.evaluate_raw(field_definition)
         if isinstance(rc, Scalar.__args__):
             return rc

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -177,12 +177,12 @@ class StandardFuncs(SnowfakeryPlugin):
                 raise ValueError("No choices supplied!")
 
             if getattr(choices[0], "function_name", None) == "choice":
-                choices = [self.context.evaluate(choice) for choice in choices]
+                choices = [self.context.evaluate_raw(choice) for choice in choices]
                 rc = weighted_choice(choices)
             else:
                 rc = random.choice(choices)
             if hasattr(rc, "render"):
-                rc = self.context.evaluate(rc)
+                rc = self.context.evaluate_raw(rc)
             return rc
 
         @lazy
@@ -218,7 +218,7 @@ class StandardFuncs(SnowfakeryPlugin):
             if not choices:
                 raise ValueError("No choices supplied!")
 
-            choices = [self.context.evaluate(choice) for choice in choices]
+            choices = [self.context.evaluate_raw(choice) for choice in choices]
             for when, choice in choices[:-1]:
                 if when is None:
                     raise SyntaxError(
@@ -231,7 +231,7 @@ class StandardFuncs(SnowfakeryPlugin):
             )
             rc = next(true_choices, choices[-1][-1])  # default to last choice
             if hasattr(rc, "render"):
-                rc = self.context.evaluate(rc)
+                rc = self.context.evaluate_raw(rc)
             return rc
 
     setattr(Functions, "if", Functions.if_)


### PR DESCRIPTION
Outputstreams will call "simplify" for PluginResults.

Example is in test_custom_plugins_and_providers

Lazy plugins can either ask for their parameters to be simplified
by calling context.evaluate() or they can use
context.evaluate_raw() if they don't care at all about the data
of their parameters (higher order function-type stuff).

A few type definitions moved around to permit code reuse without
circular references.
