### PR TITLE
Document and improve usability of target-number feature

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -886,9 +886,7 @@ Options:
 
 ### Scaling up recipe execution
 
-From the command line you can control how many rows a recipe generates by telling
-Snowfakery how many times to execute it. You do this by specifying a "target count"
-and a "target tablename", like this:
+From the command line you can control how many rows a recipe generates. You do this by specifying a "target count" and a "target tablename", like this:
 
 ```bash
 snowfakery accounts.yml --target-number 1000 Account

--- a/docs/index.md
+++ b/docs/index.md
@@ -884,7 +884,31 @@ Options:
   
 ```
 
-## CSV Output
+### Scaling up recipe execution
+
+From the command line you can control how many rows a recipe generates by telling
+Snowfakery how many times to execute it. You do this by specifying a "target count"
+and a "target tablename", like this:
+
+```bash
+snowfakery accounts.yml --target-number 1000 Account
+```
+
+The counting works like this:
+
+- Snowfakery always executes a *complete* recipe. It never stops halfway through.
+  
+- At the end of executing a recipe, it checks whether it has
+    created enough of the object type defined by ``num_records_tablename``
+  
+- If so, it finishes. If not, it runs the recipe again.
+
+So if your recipe creates 10 Accounts, 5 Contacts and 15 Opportunities,
+then when you run the command above it will run the recipe
+100 times (1000/10=100) which will generate 1000 Accounts, 500 Contacts
+and 1500 Opportunites.
+
+### CSV Output
 
 You create a CSV directory like this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -899,7 +899,7 @@ The counting works like this:
 - Snowfakery always executes a *complete* recipe. It never stops halfway through.
   
 - At the end of executing a recipe, it checks whether it has
-    created enough of the object type defined by ``num_records_tablename``
+    created enough of the object type defined by ``target-number``
   
 - If so, it finishes. If not, it runs the recipe again.
 

--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -64,7 +64,7 @@ def int_string_tuple(ctx, param, value=None):
             string, number = value[0], int(value[1])
         except ValueError:
             raise click.BadParameter(
-                "This parameter must be of the form 'number Name' like '50 Account'"
+                "This parameter must be of the form 'number Name'. For example '50 Account'"
             )
     return string, number
 

--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -47,15 +47,26 @@ def eval_arg(arg):
 
 
 # don't add a type signature to this function.
-# typeguard and click will interfer with each other.
-def string_int_tuple(ctx, param, value=None):
-    """Works around Click bug
+# typeguard and click will interfere with each other.
+def int_string_tuple(ctx, param, value=None):
+    """
+    Parse a pair of strings that represent a string and a number.
 
-    https://github.com/pallets/click/issues/789#issuecomment-535121714"""
+    Either number, string or string, number is allowed."""
     if not value:
         return None
-    else:
-        return value[0], int(value[1])
+    assert len(value) == 2
+
+    try:
+        number, string = int(value[0]), value[1]
+    except ValueError:
+        try:
+            string, number = value[0], int(value[1])
+        except ValueError:
+            raise click.BadParameter(
+                "This parameter must be of the form 'number Name' like '50 Account'"
+            )
+    return string, number
 
 
 @click.command()
@@ -81,8 +92,8 @@ def string_int_tuple(ctx, param, value=None):
 @click.option(
     "--target-number",
     nargs=2,
-    help="Target options for the recipe YAML.",
-    callback=string_int_tuple,  # noqa  https://github.com/pallets/click/issues/789#issuecomment-535121714
+    help="Target options for the recipe YAML in the form of 'number tablename' like '50 Account'.",
+    callback=int_string_tuple,  # noqa  https://github.com/pallets/click/issues/789#issuecomment-535121714
 )
 @click.option(
     "--debug-internals/--no-debug-internals", "debug_internals", default=False

--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -143,6 +143,10 @@ def generate_cli(
             * or to a directory as a set of CSV files (--output-format=csv --output-folder=csvfiles)
 
         Diagram output depends on the installation of pygraphviz ("pip install pygraphviz")
+
+        Full documentation here:
+
+            * https://snowfakery.readthedocs.io/en/docs/
     """
     output_files = list(output_files) if output_files else []
     stopping_criteria = StoppingCriteria(*target_number) if target_number else None

--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -92,7 +92,7 @@ def int_string_tuple(ctx, param, value=None):
 @click.option(
     "--target-number",
     nargs=2,
-    help="Target options for the recipe YAML in the form of 'number tablename' like '50 Account'.",
+    help="Target options for the recipe YAML in the form of 'number tablename'. For example: '50 Account'.",
     callback=int_string_tuple,  # noqa  https://github.com/pallets/click/issues/789#issuecomment-535121714
 )
 @click.option(

--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -10,6 +10,7 @@ from snowfakery.output_streams import (
 )
 from snowfakery.data_gen_exceptions import DataGenError
 from snowfakery.data_generator import generate, StoppingCriteria
+
 import sys
 from pathlib import Path
 from contextlib import contextmanager
@@ -52,7 +53,7 @@ def int_string_tuple(ctx, param, value=None):
     """
     Parse a pair of strings that represent a string and a number.
 
-    Either number, string or string, number is allowed."""
+    Either number, string or string, number is allowed as input."""
     if not value:
         return None
     assert len(value) == 2
@@ -149,7 +150,7 @@ def generate_cli(
             * https://snowfakery.readthedocs.io/en/docs/
     """
     output_files = list(output_files) if output_files else []
-    stopping_criteria = StoppingCriteria(*target_number) if target_number else None
+    stopping_criteria = stopping_criteria_from_target_number(target_number)
     output_format = output_format.lower() if output_format else None
     validate_options(
         yaml_file,
@@ -280,6 +281,18 @@ def validate_options(
         raise click.ClickException(
             "--output-folder can only be used if files are going to be output"
         )
+
+
+def stopping_criteria_from_target_number(target_number):
+    "Deconstruct a tuple of 'str number' or 'number str' and make a StoppingCriteria"
+
+    # 'number str' is the official format so the other one can be deprecated one day.
+    if target_number:
+        if isinstance(target_number[0], int):
+            target_number = target_number[1], target_number[0]
+        return StoppingCriteria(*target_number)
+
+    return None
 
 
 def main():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,26 @@ class TestGenerateFromCLI:
     def test_counts(self, write_row):
         generate_cli.callback(
             yaml_file=sample_yaml,
+            target_number=(2, "Account"),
+            option={},
+            debug_internals=None,
+            generate_cci_mapping_file=None,
+        )
+        assert write_row.mock_calls == [
+            mock.call(
+                "Account",
+                {"id": 1, "name": "Default Company Name", "ShippingCountry": "Canada"},
+            ),
+            mock.call(
+                "Account",
+                {"id": 2, "name": "Default Company Name", "ShippingCountry": "Canada"},
+            ),
+        ]
+
+    @mock.patch(write_row_path)
+    def test_counts_backwards(self, write_row):
+        generate_cli.callback(
+            yaml_file=sample_yaml,
             target_number=("Account", 2),
             option={},
             debug_internals=None,


### PR DESCRIPTION
The target-number command line was not documented. Now it is.

While documenting it, I thought it would be better if it read in the same order as English: "50 Account"(s). Both orders are supported in the code, however.