### PR TITLE
Do not serialize deep object references to continuation file

### DIFF
--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -557,7 +557,14 @@ class ObjectRow(yaml.YAMLObject):
         return f"<ObjectRow {self._tablename} {self.id}>"
 
     def __getstate__(self):
-        return {"_tablename": self._tablename, "_values": self._values}
+        """Get the state of this ObjectRow for serialization.
+
+        Do not include related ObjectRows because circular
+        references in serialization formats cause problems."""
+        values = [
+            (k, v) for k, v in self._values.items() if not isinstance(v, ObjectRow)
+        ]
+        return {"_tablename": self._tablename, "_values": values}
 
     def __setstate__(self, state):
         for slot, value in state.items():


### PR DESCRIPTION
Do not serialize deep object references to continuation file. They sometimes cause reference loops which YAML cannot (in this case) load.