### PR TITLE
Implement a shorter form of random_choice

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -449,6 +449,24 @@ StageName:
 
 You can do more sophisticated randomness with features that will be discussed in the section [Random Weights That Are Not Percentages](#random-weights-that-are-not-percentages).
 
+A more elaborate form of `random_choice` can also be used to
+select randomly among potential child or friend objects.
+
+```yaml
+- object : Task
+  fields:
+    who:
+        random_choice:
+          - object: Contact
+            fields:
+                FirstName: Bart
+                LastName: Simpson
+          - object: Lead
+            fields:
+                FirstName: Marge
+                LastName: Simpson
+```
+
 ### `fake`
 
 Generate fake data using functions from the [faker](https://github.com/joke2k/faker) library:

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import pytest
 import unittest
 from unittest import mock
 
@@ -264,3 +265,43 @@ class TestTemplateFuncs(unittest.TestCase):
         """
         generate(StringIO(yaml), {}, None)
         assert write_row.mock_calls[3][1][1]["num"] == 2
+
+    def test_random_choice_error_args_and_kwargs(self):
+        yaml = """
+        - object: A
+          fields:
+            num: ${{random_choice(1,2,a=10,b=20)}}
+        """
+        with pytest.raises(DataGenError):
+            generate(StringIO(yaml))
+
+    @mock.patch(write_row_path)
+    def test_random_choice_error_no_choices(self, write_row):
+        yaml = """
+        - object: A
+          fields:
+            num: ${{random_choice()}}
+        """
+        with pytest.raises(DataGenError):
+            generate(StringIO(yaml))
+
+    @mock.patch(write_row_path)
+    def test_random_choice_error_no_choices_2(self, write_row):
+        yaml = """
+        - object: A
+          fields:
+            num:
+                random_choice:
+        """
+        with pytest.raises(DataGenError):
+            generate(StringIO(yaml))
+
+    @mock.patch(write_row_path)
+    def test_if_error_no_choices(self, write_row):
+        yaml = """
+        - object: A
+          fields:
+            num: ${{if()}}
+        """
+        with pytest.raises(DataGenError):
+            generate(StringIO(yaml))


### PR DESCRIPTION
The docs described a more concise form of random_choice that was not actually implemented. Now it is. The more verbose form is still available and its motivation is described in the documentation.