### PR TITLE
Handle some corner cases

### DIFF
--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -286,15 +286,17 @@ class TestTemplateFuncs(unittest.TestCase):
             generate(StringIO(yaml))
 
     @mock.patch(write_row_path)
-    def test_random_choice_error_no_choices_2(self, write_row):
+    def test_random_choice_can_generate_None(self, write_row):
         yaml = """
         - object: A
           fields:
-            num:
+            void:
                 random_choice:
+                    -
+                    -
         """
-        with pytest.raises(DataGenError):
-            generate(StringIO(yaml))
+        generate(StringIO(yaml))
+        write_row.mock_calls[0][1][1]["void"] is None
 
     @mock.patch(write_row_path)
     def test_if_error_no_choices(self, write_row):


### PR DESCRIPTION
A couple of corner cases which changed in recent versions.

Allow "none" as a return code from random_choice because sometimes NULL is a real choice.

Allow random_choice with a single item. It previously allowed this. Machine-generated Snowfakery files may sometimes generate a single-item random_choice.