### PR TITLE
Fixes relating to continuation handling.

### DIFF
--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -133,7 +133,7 @@ class StandardFuncs(SnowfakeryPlugin):
                 obj = self.context.field_vars().get(x)
                 if not obj:
                     raise DataGenError(f"Cannot find an object named {x}", None, None)
-                if not getattr(obj, "id"):
+                if not getattr(obj, "id", None):
                     raise DataGenError(
                         f"Reference to incorrect object type {obj}", None, None
                     )

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -60,11 +60,6 @@ id_manager:
   last_used_ids:
     foo: 41
     bar: 1000
-last_seen_obj_of_type:
-  foo:
-    id: 41
-  bar:
-    id: 1000
 nicknames_and_tables: {}
 today: 2022-11-03
                 """

--- a/tests/test_data_generator_runtime.py
+++ b/tests/test_data_generator_runtime.py
@@ -1,0 +1,22 @@
+from snowfakery.data_generator_runtime import ObjectRow
+
+
+class TestObjectRow:
+    def test_repr(self):
+        "Test repr handles even invalid objects, for debugging"
+        obj = ObjectRow("A", {"id": "5", "b": "c"})
+        assert repr(obj)
+        called = False
+
+        class ProblemValue:
+            def __repr__(self):
+                nonlocal called
+                called = True
+                raise Exception()
+
+        obj = ObjectRow(ProblemValue(), {"id": ProblemValue()})
+        assert repr(obj)
+        assert called
+
+        obj = ObjectRow("", {})
+        assert repr(obj)

--- a/tests/test_restartability.py
+++ b/tests/test_restartability.py
@@ -1,29 +1,40 @@
-import unittest
 from unittest import mock
 from io import StringIO
 
 from snowfakery.data_generator import generate
 
 
-class TestRestart(unittest.TestCase):
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_nicknames_persist(self, write_row):
+class TestRestart:
+    def test_nicknames_persist(self, generated_rows):
         yaml = """
             - object: foo
               nickname: Foo
+              just_once: True
+              fields:
+                A: 25
             - object: bar
               fields:
                 foo_reference:
                     reference: Foo
+                A: ${{Foo.A}}
+            - object: baz
+              fields:
+                bar_reference:
+                    reference: bar
             """
         continuation_file = StringIO()
         generate(StringIO(yaml), generate_continuation_file=continuation_file)
+        next_contination_file = StringIO()
         generate(
-            StringIO(yaml), continuation_file=StringIO(continuation_file.getvalue())
+            StringIO(yaml),
+            continuation_file=StringIO(continuation_file.getvalue()),
+            generate_continuation_file=next_contination_file,
         )
 
-        assert write_row.mock_calls[1][1][1]["foo_reference"].id == 1
-        assert write_row.mock_calls[3][1][1]["foo_reference"].id == 2
+        assert generated_rows.row_values(1, "foo_reference") == "foo(1)"
+        assert generated_rows.row_values(2, "bar_reference") == "bar(1)"
+        assert generated_rows.row_values(3, "foo_reference") == "foo(1)"
+        assert generated_rows.row_values(4, "bar_reference") == "bar(2)"
 
     @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
     def test_ids_go_up(self, write_row):


### PR DESCRIPTION
The Snowfakery docs say:

> references are always to objects
created within the current "batch" of a recipe and never to a previous
batch with only one exception: objects marked 'just_once' are always
created only in the first run and references to them are to the
objects created in that first batch.

Given this, there is no point keeping track of objects created in previous iterations of the recipe other than those with nicknames, so Snowfakery does not do that anymore.

Also fixes two bugs which could cause crashes relating to the intersection of a) forward references, b) nicknames and c) continuations.

One solution is not to serialize "nickname slots" into the continuation file because they add no value and we are not trying to serialize deep hierarchies of ObjectRows.

A second bugfix is to ensure that if a persistent (just_once) nickname fulfills a nickname slot then it grabs the slot as soon as the interpreter is re-initialized.

Finally, made the repr() for an object more robust so that even buggy objects can print themselves out for debugging.
