### PR TITLE
Improve casting of datetimes to dates and test coverage

### DIFF
--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -48,10 +48,11 @@ def weighted_choice(choices: List[Tuple[float, object]]):
 
 @lru_cache(maxsize=512)
 def parse_date(d: Union[str, datetime, date]) -> date:
-    if isinstance(d, date):
-        return d
-    elif isinstance(d, datetime):
+    if isinstance(d, datetime):
         return d.date()
+    elif isinstance(d, date):
+        return d
+
     return dateutil.parser.parse(d).date()
 
 

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -232,6 +232,16 @@ class TestTemplateFuncs:
         assert write_row.mock_calls[0][1][1]["a"] == "2012-01-01"
 
     @mock.patch(write_row_path)
+    def test_date_from_datetime(self, write_row):
+        yaml = """
+        - object : A
+          fields:
+            a: ${{date(datetime(year=2012, month=1, day=1))}}
+        """
+        generate(StringIO(yaml), {}, None)
+        assert write_row.mock_calls[0][1][1]["a"] == "2012-01-01"
+
+    @mock.patch(write_row_path)
     def test_old_syntax(self, write_row):
         yaml = """
         - object : A


### PR DESCRIPTION
Improve casting of datetimes to dates and test coverage

Previously, datetimes would be returned unchanged. Now, the time part will be truncated properly.