### PR TITLE
Allow fields to be specified in any order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML==5.3.1
 click==7.1.2
 python-dateutil==2.8.1
 gvgen==1.0
+networkx==2.5

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -510,6 +510,9 @@ class RuntimeContext:
     def context_vars(self, plugin_namespace):
         return self._context_vars.setdefault(plugin_namespace, {})
 
+    def object_names(self):
+        return self.evaluation_namespace.object_names()
+
 
 # NamedTuple because it is immutable, efficient and auto-generates init
 class EvaluationNamespace(NamedTuple):
@@ -553,6 +556,9 @@ class EvaluationNamespace(NamedTuple):
 
     def field_vars(self):
         return {**self.simple_field_vars(), **self.field_funcs()}
+
+    def object_names(self):
+        return self.runtime_context.interpreter.globals.object_names
 
 
 def evaluate_function(func, args: Sequence, kwargs: Mapping, context):

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -575,15 +575,12 @@ class ObjectRow(yaml.YAMLObject):
     yaml_dumper = SnowfakeryDumper
     yaml_tag = "!snowfakery_objectrow"
 
-    __slots__ = ["_tablename", "_values", "_child_index", "_lazy_evaluators"]
+    __slots__ = ["_tablename", "_values", "_child_index"]
 
-    def __init__(
-        self, tablename, values: dict, index: int = 0, lazy_evaluators: dict = ()
-    ):
+    def __init__(self, tablename, values: dict, index: int = 0):
         self._tablename = tablename
         self._values = values
         self._child_index = index
-        self._lazy_evaluators = lazy_evaluators
 
     def __getattr__(self, name):
         if name in self._values:
@@ -592,8 +589,6 @@ class ObjectRow(yaml.YAMLObject):
                 return value()
             else:
                 return value
-        elif name in self._lazy_evaluators:
-            return self._lazy_evaluators[name].evaluate()
         else:
             raise AttributeError(name)
 
@@ -620,11 +615,6 @@ class ObjectRow(yaml.YAMLObject):
     def __setstate__(self, state):
         for slot, value in state.items():
             setattr(self, slot, value)
-        self._lazy_evaluators = ()
-
-    @property
-    def _name(self):
-        return self._values.get("name")
 
 
 def output_batches(

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -581,21 +581,23 @@ class ObjectRow(yaml.YAMLObject):
     yaml_dumper = SnowfakeryDumper
     yaml_tag = "!snowfakery_objectrow"
 
-    __slots__ = ["_tablename", "_values", "_child_index"]
+    __slots__ = ["_tablename", "_values", "_child_index", "_fallback_func"]
 
-    def __init__(self, tablename, values: dict, index: int = 0):
+    def __init__(self, tablename, values: dict, index: int = 0, fallback_func=None):
         self._tablename = tablename
         self._values = values
         self._child_index = index
+        self._fallback_func = fallback_func or (lambda x: None)
 
     def __getattr__(self, name):
-        if name in self._values:
-            value = self._values[name]
-            if callable(value):
-                return value()
-            else:
-                return value
-        else:
+        try:
+            return self._values[name]
+        except KeyError:
+            pass
+
+        try:
+            return self._fallback_func(name)
+        except KeyError:
             raise AttributeError(name)
 
     def __str__(self):

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -173,7 +173,7 @@ class ObjectTemplate:
             }
         )
 
-        sobj = ObjectRow(self.tablename, row, index, {})
+        sobj = ObjectRow(self.tablename, row, index)
 
         context.register_object(sobj, self.nickname)
 

--- a/snowfakery/generate_mapping_from_recipe.py
+++ b/snowfakery/generate_mapping_from_recipe.py
@@ -109,6 +109,8 @@ def _table_is_free(table_name, dependencies, sorted_tables):
     return len(tables_this_table_depends_upon) == 0
 
 
+# if this algorithm ever needs major updates, it should be rewritten
+# with networkx similar to _sort_fields_by_dependencies
 def sort_dependencies(dependencies, tables):
     """"Sort the dependencies to output tables in the right order."""
     dependencies = deepcopy(dependencies)

--- a/snowfakery/plugins.py
+++ b/snowfakery/plugins.py
@@ -81,6 +81,9 @@ class PluginContext:
             self.plugin.__class__.__name__
         )
 
+    def object_names(self):
+        return self.interpreter.current_context.object_names()
+
     def evaluate_raw(self, field_definition):
         """Evaluate the contents of a field definition"""
         return field_definition.render(self.interpreter.current_context)
@@ -146,6 +149,7 @@ class PluginResult:
 
     def __str__(self):
         return str(self.result)
+
 
 # round-trip PluginResult objects through continuation YAML if needed.
 SnowfakeryDumper.add_representer(PluginResult, Representer.represent_object)

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -131,7 +131,8 @@ class StandardFuncs(SnowfakeryPlugin):
             if hasattr(x, "id"):  # reference to an object with an id
                 target = x
             elif isinstance(x, str):  # name of an object
-                obj = self.context.field_vars().get(x)
+                obj = self.context.object_names().get(x)
+                obj = obj or self.context.field_values.get(x)
                 if callable(obj):
                     raise DataGenError(
                         f"A reference should not be to a field name: `{x}`", None, None

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -132,11 +132,15 @@ class StandardFuncs(SnowfakeryPlugin):
                 target = x
             elif isinstance(x, str):  # name of an object
                 obj = self.context.field_vars().get(x)
+                if callable(obj):
+                    raise DataGenError(
+                        f"A reference should not be to a field name: `{x}`", None, None
+                    )
                 if not obj:
-                    raise DataGenError(f"Cannot find an object named {x}", None, None)
+                    raise DataGenError(f"Cannot find an object named `{x}`", None, None)
                 if not getattr(obj, "id", None):
                     raise DataGenError(
-                        f"Reference to incorrect object type {obj}", None, None
+                        f"Reference to incorrect object type `{obj}`", None, None
                     )
                 target = obj
             else:

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -133,10 +133,6 @@ class StandardFuncs(SnowfakeryPlugin):
             elif isinstance(x, str):  # name of an object
                 obj = self.context.object_names().get(x)
                 obj = obj or self.context.field_values.get(x)
-                if callable(obj):
-                    raise DataGenError(
-                        f"A reference should not be to a field name: `{x}`", None, None
-                    )
                 if not obj:
                     raise DataGenError(f"Cannot find an object named `{x}`", None, None)
                 if not getattr(obj, "id", None):

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -104,5 +104,5 @@ today: 2022-11-03
           just_once: True
         - object: bar
         """
-        with self.assertRaises(DataGenNameError, match="No template creating"):
+        with pytest.raises(DataGenNameError, match="No template creating"):
             generate(StringIO(yaml), stopping_criteria=StoppingCriteria("foot", 3))

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -89,8 +89,7 @@ today: 2022-11-03
             mock.call("bar", {"id": 3}),
         ]
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_stops_on_no_progress(self, write_row):
+    def test_stops_on_no_progress(self):
         yaml = """
         - object: foo
           just_once: True
@@ -98,3 +97,12 @@ today: 2022-11-03
         """
         with self.assertRaises(RuntimeError):
             generate(StringIO(yaml), stopping_criteria=StoppingCriteria("foo", 3))
+
+    def test_stops_on_misnamed_object(self):
+        yaml = """
+        - object: foo
+          just_once: True
+        - object: bar
+        """
+        with self.assertRaises(DataGenNameError, match="No template creating"):
+            generate(StringIO(yaml), stopping_criteria=StoppingCriteria("foot", 3))

--- a/tests/test_data_generator_runtime.py
+++ b/tests/test_data_generator_runtime.py
@@ -1,4 +1,4 @@
-from snowfakery.data_generator_runtime import ObjectRow
+from snowfakery.data_generator_runtime import ObjectRow, NicknameSlot
 
 
 class TestObjectRow:
@@ -20,3 +20,10 @@ class TestObjectRow:
 
         obj = ObjectRow("", {})
         assert repr(obj)
+
+
+class TestNicknameSlot:
+    def test_nickname_slot(self):
+        n = NicknameSlot("Foo", None)
+        repr(n)
+        str(n)

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -19,6 +19,20 @@ class TestFormulas:
         generate(StringIO(yaml), {})
         assert generated_rows.row_values(0, "total") == 60
 
+    def test_simple_math_fields_nested_not_ordered(self, generated_rows):
+        yaml = """
+        - object: parent
+          fields:
+            a: 10
+            total_obj:
+              - object: total
+                fields:
+                  t: ${{parent.a + parent.b}}
+            b: 20
+        """
+        generate(StringIO(yaml), {})
+        assert generated_rows.row_values(0, "t") == 30
+
     def test_self_reference__error(self):
         yaml = """
         - object: XXX

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -1,0 +1,39 @@
+from io import StringIO
+
+import pytest
+
+from snowfakery.data_generator import generate
+from snowfakery.data_gen_exceptions import DataGenError
+
+
+class TestFormulas:
+    def test_simple_math_fields_not_ordered(self, generated_rows):
+        yaml = """
+        - object: XXX
+          fields:
+            total: ${{a + (b + c)}}
+            a: 10
+            b: 20
+            c: 30
+        """
+        generate(StringIO(yaml), {})
+        assert generated_rows.row_values(0, "total") == 60
+
+    def test_self_reference__error(self):
+        yaml = """
+        - object: XXX
+          fields:
+            a: XXX ${{a}} YYY
+        """
+        with pytest.raises(DataGenError, match="Field cycles detected"):
+            generate(StringIO(yaml), {})
+
+    def test_circular_references__error(self):
+        yaml = """
+        - object: XXX
+          fields:
+            a: XXX ${{(b)}} YYY
+            b: XXX ${{(a+(a+b))}} YYY
+        """
+        with pytest.raises(DataGenError, match="Field cycles detected"):
+            generate(StringIO(yaml), {})


### PR DESCRIPTION
Snowfakery fields can now be specified in any order and formulas will still find them.

This is implemented through two mechanisms:

1. Fields are sorted before evaluation based on their relationships to each other (handles most cases)
2. Fields have lazy proxies (lambdas) that stand in for them in case their values are needed before they are evaluated (handles some corner cases relating to nested objects)

This version should be performance-tested because the lazy proxies have a cost.

Fixes #205
