### PR TITLE
Fix option names in help text

### DIFF
--- a/snowfakery/cli.py
+++ b/snowfakery/cli.py
@@ -143,8 +143,8 @@ def generate_cli(
     \b
         Records can go to:
             * stdout (default)
-            * JSON file (--output_format=json --output-file=foo.json)
-            * diagram file (--output_format=png --output-file=foo.png)
+            * JSON file (--output-format=json --output-file=foo.json)
+            * diagram file (--output-format=png --output-file=foo.png)
             * a database identified by --dburl (e.g. --dburl sqlite:////tmp/foo.db)
             * or to a directory as a set of CSV files (--output-format=csv --output-folder=csvfiles)
 


### PR DESCRIPTION
I just ran into this while copy and pasting from the help text. Results in: `Error: no such option: --output_format`

# Changes
* Fixed option names in the help text. 