### PR TITLE
Use new syntax everywhere

### DIFF
--- a/examples/EDA/eda_macros.yml
+++ b/examples/EDA/eda_macros.yml
@@ -187,7 +187,7 @@
         start_date: -1y
         end_date: today
     __hed__Applicant__c__disabled: "OPTIONAL REFERENCE SKIPPED: ['Contact']"
-    hed__Application_Date__c: <<fake.date>>T<<fake.time>>Z
+    hed__Application_Date__c: ${{fake.date}}T${{fake.time}}Z
     hed__Application_Decision_Date__c:
       date_between:
         start_date: -1y

--- a/examples/EDA/eda_objects.yml
+++ b/examples/EDA/eda_objects.yml
@@ -127,7 +127,7 @@
         end_date: today
     hed__Applicant__c:
       reference: Contact
-    hed__Application_Date__c: <<fake.date>>T<<fake.time>>Z
+    hed__Application_Date__c: ${{fake.date}}T${{fake.time}}Z
     hed__Application_Decision_Date__c:
       date_between:
         start_date: -1y

--- a/examples/npsp/Contact_npsp.recipe.yml
+++ b/examples/npsp/Contact_npsp.recipe.yml
@@ -245,7 +245,7 @@
     EmailBouncedReason:
       fake.text:
         max_nb_chars: 100
-    EmailBouncedDate: <<fake.date>>T<<fake.time>>Z
+    EmailBouncedDate: ${{fake.date}}T${{fake.time}}Z
     CleanStatus:
       random_choice:
         - Matched

--- a/examples/salesforce/Contact.recipe.yml
+++ b/examples/salesforce/Contact.recipe.yml
@@ -138,7 +138,7 @@
     EmailBouncedReason:
       fake.text:
         max_nb_chars: 100
-    EmailBouncedDate: <<fake.date>>T<<fake.time>>Z
+    EmailBouncedDate: ${{fake.date}}T${{fake.time}}Z
     CleanStatus:
       random_choice:
         - Matched

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -272,16 +272,16 @@ class JinjaTemplateEvaluatorFactory:
     def __init__(self):
         self.compilers = [
             jinja2.Environment(
-                block_start_string="<%",
-                block_end_string="%>",
-                variable_start_string="<<",
-                variable_end_string=">>",
-            ),
-            jinja2.Environment(
                 block_start_string="${%",
                 block_end_string="%}",
                 variable_start_string="${{",
                 variable_end_string="}}",
+            ),
+            jinja2.Environment(
+                block_start_string="<%",
+                block_end_string="%>",
+                variable_start_string="<<",
+                variable_end_string=">>",
             ),
         ]
 

--- a/tests/test_data_generator_runtime_dom.py
+++ b/tests/test_data_generator_runtime_dom.py
@@ -137,6 +137,14 @@ class TestDataGeneratorRuntimeDom(unittest.TestCase):
         x = f.generate_value(standard_runtime())
         assert x == 15
 
+    def test_mixed_jinja_syntax(self):
+        definition = SimpleValue("${{2+3}} <<5*3>>", "abc.yml", 10)
+        repr(definition)
+        f = FieldFactory("field", definition, "abc.yml", 10)
+        repr(f)
+        x = f.generate_value(standard_runtime())
+        assert x == "5 <<5*3>>"
+
     def test_check_type(self):
         o = ObjectTemplate("abcd", filename="abc.yml", line_num=10)
         field = mock.MagicMock()

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -216,7 +216,7 @@ class TestTemplateFuncs:
         yaml = """
         - object : A
           fields:
-            a: <<date("2012-01-01T00:01")>>
+            a: ${{date("2012-01-01T00:01")}}
         """
         generate(StringIO(yaml), {}, None)
         assert write_row.mock_calls[0][1][1]["a"] == "2012-01-01"
@@ -246,7 +246,7 @@ class TestTemplateFuncs:
         yaml = """
         - object : A
           fields:
-            a: <<5 + 3>>
+            a: ${{5 + 3}}
         """
         generate(StringIO(yaml), {}, None)
         assert write_row.mock_calls[0][1][1]["a"] == 8
@@ -284,7 +284,7 @@ class TestTemplateFuncs:
             - object: B
               count: 3
               fields:
-                    num: <<child_index>>
+                    num: ${{child_index}}
         """
         generate(StringIO(yaml), {}, None)
         assert write_row.mock_calls[3][1][1]["num"] == 2


### PR DESCRIPTION
Changes: 

1. all examples use the new syntax (except a couple of unit tests)

2. if a template uses both syntaxes, the new syntax parts will work properly. The old syntax parts won't. This is better than the previous situation which would guide you to the conclusion that the problem is in the new-style syntax.
