### PR TITLE
Code cleanups

### DIFF
--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -48,7 +48,13 @@ class FieldDefinition(ABC):
 
 
 class VariableDefinition:
-    """Defines a mutable variable"""
+    """Defines a mutable variable. Like:
+
+    - var: Foo
+      value: Bar
+    """
+
+    # TODO: Add an example
 
     tablename = None
 
@@ -210,7 +216,7 @@ class ObjectTemplate:
 
 
 class SimpleValue(FieldDefinition):
-    """A value with no sub-structure (although it could hold a template)
+    """A value with no sub-structure (although it could hold a formula)
 
     - object: abc
       fields:
@@ -336,13 +342,6 @@ class StructuredValue(FieldDefinition):
         return (
             f"<StructuredValue: {self.function_name} (*{self.args}, **{self.kwargs})>"
         )
-
-
-class ReferenceValue(StructuredValue):
-    """- object: foo
-    fields:
-      - reference:
-          Y"""
 
 
 class FieldFactory:

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from collections import namedtuple, defaultdict
 from typing import Dict, Union, Optional, Mapping, Callable, Sequence
+from warnings import warn
 
 from sqlalchemy import create_engine, MetaData, Column, Integer, Table, Unicode, func
 from sqlalchemy.ext.automap import automap_base
@@ -252,22 +253,24 @@ class JSONOutputStream(FileOutputStream):
 class SqlDbOutputStream(OutputStream):
     """Output stream for talking to SQL Databases"""
 
-    mappings = None
     should_close_session = False
 
-    def __init__(self, engine: Engine, mappings: Optional[Dict]):
+    def __init__(self, engine: Engine, mappings: None = None):
+        if mappings:
+            warn("Please do not pass mapping argument to __init__", DeprecationWarning)
         self.buffered_rows = defaultdict(list)
         self.table_info = {}
-        self.mappings = mappings
         self.engine = engine
         self.session = create_session(bind=self.engine, autocommit=False)
         self.metadata = MetaData(bind=self.engine)
         self.base = automap_base(bind=engine, metadata=self.metadata)
 
     @classmethod
-    def from_url(cls, db_url: str, mappings: Optional[Dict] = None):
+    def from_url(cls, db_url: str, mappings: None = None):
+        if mappings:
+            warn("Please do not pass mapping argument to from_url", DeprecationWarning)
         engine = create_engine(db_url)
-        self = cls(engine, mappings)
+        self = cls(engine)
         return self
 
     def write_single_row(self, tablename: str, row: Dict) -> None:
@@ -305,8 +308,6 @@ class SqlDbOutputStream(OutputStream):
         self.session.close()
 
     def create_or_validate_tables(self, inferred_tables: Dict[str, TableInfo]) -> None:
-        if self.mappings:
-            _validate_fields(self.mappings, inferred_tables)
         create_tables_from_inferred_fields(inferred_tables, self.engine, self.metadata)
         self.metadata.create_all()
         self.base.prepare(self.engine, reflect=True)
@@ -343,7 +344,7 @@ class SqlTextOutputStream(FileOutputStream):
         "Initialize a db through an owned output stream"
         db_url = f"sqlite:///{self.tempdir.name}/tempdb.db"
         engine = create_engine(db_url)
-        return SqlDbOutputStream(engine, None)
+        return SqlDbOutputStream(engine)
 
     def write_single_row(self, tablename: str, row: Dict) -> None:
         self.sql_db.write_single_row(tablename, row)
@@ -373,11 +374,6 @@ class SqlTextOutputStream(FileOutputStream):
         self.sql_db.close(*args, **kwargs)
         self.text_output.close(*args, **kwargs)
         self.tempdir.cleanup()
-
-
-def _validate_fields(mappings, tables):
-    """Validate that the field names detected match the mapping"""
-    pass  # TODO
 
 
 def create_tables_from_inferred_fields(tables, engine, metadata):

--- a/snowfakery/parse_recipe_yaml.py
+++ b/snowfakery/parse_recipe_yaml.py
@@ -17,7 +17,6 @@ from .data_generator_runtime_object_model import (
     FieldFactory,
     SimpleValue,
     StructuredValue,
-    ReferenceValue,
     Statement,
     Definition,
 )
@@ -190,10 +189,7 @@ def parse_structured_value(name: str, field: Dict, context: ParseContext) -> Def
         return rc
     else:
         args = parse_structured_value_args(args, context)
-        if function_name == "reference":
-            return ReferenceValue(function_name, args, **context.line_num(field))
-        else:
-            return StructuredValue(function_name, args, **context.line_num(field))
+        return StructuredValue(function_name, args, **context.line_num(field))
 
 
 def parse_field_value(
@@ -582,7 +578,7 @@ def parse_file(stream: IO[str], context: ParseContext) -> List[Dict]:
 
     if not isinstance(data, list):
         raise exc.DataGenSyntaxError(
-            "Generator file should be a list (use '-' on top-level lines)",
+            "Recipe file should be a list (use '-' on top-level lines)",
             stream_name,
             1,
         )

--- a/snowfakery/standard_plugins/Salesforce.py
+++ b/snowfakery/standard_plugins/Salesforce.py
@@ -3,7 +3,7 @@ from snowfakery.data_generator_runtime_object_model import (
     ObjectTemplate,
     FieldFactory,
     SimpleValue,
-    ReferenceValue,
+    StructuredValue,
 )
 from snowfakery import data_gen_exceptions as exc
 
@@ -37,7 +37,7 @@ class Salesforce(ParserMacroPlugin):
             ),
             FieldFactory(
                 "AccountId",
-                ReferenceValue("reference", ["Account"], **line_info),
+                StructuredValue("reference", ["Account"], **line_info),
                 **line_info,
             ),
         ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,9 +104,7 @@ class TestGenerateFromCLI:
 
     @mock.patch(write_row_path)
     def test_with_debug_flags_on(self, write_row):
-        generate_cli.callback(
-            yaml_file=sample_yaml, option={}, debug_internals=True, mapping_file=None
-        )
+        generate_cli.callback(yaml_file=sample_yaml, option={}, debug_internals=True)
 
     @mock.patch(write_row_path)
     def test_exception_with_debug_flags_on(self, write_row):
@@ -227,8 +225,6 @@ class TestGenerateFromCLI:
             generate_cli.main(
                 [
                     str(sample_yaml),
-                    "--cci-mapping-file",
-                    mapping_file_path,
                     "--dburl",
                     database_url,
                     "--continuation-file",

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -142,7 +142,7 @@ class TestSqlDbOutputStream(unittest.TestCase, OutputCommonTests):
     def do_output(self, yaml):
         with named_temporary_file_path() as f:
             url = f"sqlite:///{f}"
-            output_stream = SqlDbOutputStream.from_url(url, None)
+            output_stream = SqlDbOutputStream.from_url(url)
             results = generate(StringIO(yaml), {}, output_stream)
             table_names = results.tables.keys()
             output_stream.close()

--- a/tests/test_with_cci.py
+++ b/tests/test_with_cci.py
@@ -24,8 +24,6 @@ class Test_CLI_CCI(unittest.TestCase):
             url = f"sqlite:///{t}/foo.db"
             generate_cli.main(
                 [
-                    "--cci-mapping-file",
-                    str(sample_mapping_yaml),
                     str(sample_accounts_yaml),
                     "--dburl",
                     url,


### PR DESCRIPTION
Things I noticed after reviewing the code with Brandon and Aishanya.

In the early days of Snowfakery, mapping files were inputs rather than outputs. The last vestiges of those days are removed in this pull request.

In the early days of Snowfakery, references were inferred at parse time rather than on the basis of an actual execution of the recipe. Therefore a special "Reference" object was added to the parse tree for this analysis. Now the analysis is based on the output and the special Reference object is not needed.

A few other doc cleanups.
