### PR TITLE
Allow binary or text data to be included and sent to Salesforce

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -58,6 +58,13 @@ tasks:
             num_records: 100
             num_records_tablename: Opportunity
 
+    generate_content_documents:
+        class_path: cumulusci.tasks.bulkdata.generate_and_load_data_from_yaml.GenerateAndLoadDataFromYaml
+        options:
+            generator_yaml: examples/salesforce/ContentVersion.recipe.yml
+            num_records: 10
+            num_records_tablename: Account
+
 flows:
     test_everything:
         steps:
@@ -79,6 +86,8 @@ flows:
                 task: generate_opportunity_contact_roles
             9:
                 task: generate_opportunities_and_contacts
+            10:
+                task: generate_content_documents
 
     contacts_for_accounts:
         steps:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1525,7 +1525,7 @@ You can read and include Unicode files like this:
 ```yaml
 - plugin: snowfakery.standard_plugins.file.File
 
-- object: BinaryData
+- object: UnicodeData
   fields:
     encoded_data:
       - File.file_data:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1613,7 +1613,7 @@ There is also an alternate syntax which allows nicknaming:
 
 #### ContentVersions
 
-Files can be used as Salesforce ContentVersins like this:
+Files can be used as Salesforce ContentVersions like this:
 
 ```yaml
 - plugin: snowfakery.standard_plugins.base64.Base64

--- a/docs/index.md
+++ b/docs/index.md
@@ -1518,6 +1518,36 @@ recipe once. It could, however, save you time if you  were running
 the Snowfakery recipe over and over, because the shuffling would
 happen just once.
 
+#### Reading files
+
+You can read and include Unicode files like this:
+
+```yaml
+- plugin: snowfakery.standard_plugins.file.File
+
+- object: BinaryData
+  fields:
+    encoded_data:
+      - File.file_data:
+          encoding: utf-8
+          file: ../CODE_OF_CONDUCT.md
+```
+
+You can read and include Binary files like this:
+
+```yaml
+- plugin: snowfakery.standard_plugins.base64.Base64
+- plugin: snowfakery.standard_plugins.file.File
+
+- object: BinaryData
+  fields:
+    encoded_data:
+      Base64.encode:
+        - File.file_data:
+            encoding: binary
+            file: salesforce/example.pdf
+```
+
 ### Salesforce Plugin
 
 There are several features planned for the Salesforce Plugin, but
@@ -1581,7 +1611,32 @@ There is also an alternate syntax which allows nicknaming:
       reference: PCPC
 ```
 
+#### ContentVersions
 
+Files can be used as Salesforce ContentVersins like this:
+
+```yaml
+- plugin: snowfakery.standard_plugins.base64.Base64
+- plugin: snowfakery.standard_plugins.file.File
+- object: Account
+  nickname: FileOwner
+  fields:
+    Name:
+      fake: company
+- object: ContentVersion
+  nickname: FileAttachment
+  fields:
+    Title: Attachment for ${{Account.Name}}
+    PathOnClient: example.pdf
+    Description: example.pdf
+    VersionData:
+      Base64.encode:
+        - File.file_data:
+            encoding: binary
+            file: ${{PathOnClient}}
+    FirstPublishLocationId:
+      reference: Account
+```
 
 ### Custom Plugins
 

--- a/examples/binary.recipe.yml
+++ b/examples/binary.recipe.yml
@@ -1,0 +1,10 @@
+- plugin: snowfakery.standard_plugins.base64.Base64
+- plugin: snowfakery.standard_plugins.file.File
+
+- object: BinaryData
+  fields:
+    encoded_data:
+      Base64.encode:
+        - File.file_data:
+            encoding: binary
+            file: salesforce/example.pdf

--- a/examples/salesforce/ContentVersion.recipe.yml
+++ b/examples/salesforce/ContentVersion.recipe.yml
@@ -1,0 +1,20 @@
+- plugin: snowfakery.standard_plugins.base64.Base64
+- plugin: snowfakery.standard_plugins.file.File
+- object: Account
+  nickname: FileOwner
+  fields:
+    Name:
+      fake: company
+- object: ContentVersion
+  nickname: FileAttachment
+  fields:
+    Title: Attachment for ${{Account.Name}}
+    PathOnClient: example.pdf
+    Description: example.pdf
+    VersionData:
+      Base64.encode:
+        - File.file_data:
+            encoding: binary
+            file: ${{PathOnClient}}
+    FirstPublishLocationId:
+      reference: Account

--- a/examples/salesforce/example.pdf
+++ b/examples/salesforce/example.pdf
@@ -1,0 +1,107 @@
+%PDF-1.3
+%âãÏÓ
+7 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+6 0 obj
+<<
+/Filter /FlateDecode
+/Length 301
+>>
+stream
+xœµ“QKÃ0…ßû+Î£‚^Û¬iÓÇM·a X|kÚf´éhR½Û@V6&bHä~'9$ÏÁ"BøŞWÁÃ*K‘—Oi–r¤ŒÈ‹às¼êv×(¼<­°Òãâù6Xæá+£ĞW&1DJÂCe^k‹qHØV6
+ÕvÆº^:İĞ®(QzŞıOâ“Ä”†ñ³¬CÙõ¬‚6pµÂ›îİ ¬Õ¦–Fo,Üàº^ËÆÖ]¯àÔ‡#ÌMÖË©g”r¶·8Ù|œ™ SûêœœZD	‰,¹pæÅ˜©îğéÛ5FS0¦,>Dÿç+œÉŠgŒ²Œ]“Õ´vœBñ¯9óñD³K9ŸÈå»2ßšğØ§Í 
+Œ|'+":z|†c$
+endstream
+endobj
+4 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 612 792]
+/Resources <<
+/Font <<
+/F1 7 0 R
+>>
+>>
+/Contents 6 0 R
+/Parent 2 0 R
+>>
+endobj
+8 0 obj
+<<
+/Filter /FlateDecode
+/Length 265
+>>
+stream
+xœ‘OO„0Åï|ŠwÔd3B…å`b4‘‹G\
+t-ÜooùcÜdãÆ˜:“Î{¿™Ã“—dùô•w“`YéE‚nEÁ±Yá]áMµ]#ñú"U.`¸Fvğ³ÙbVş¬äwÄ"ğ8&îoJ"Úm•e²7-º¼’ïÒ¢5½„•Ÿ–p¯‹é	nƒN<â+ä²öé9‚‡$üpE¬Å/õµ™ğaz¥+Øc·\µ0Ø±,	Éh¡E>|¹hÊí¾ãsFÄHDlet¹ÒEüï¿ıUèÓ¶dé‰€gW¿CFYëz"Ïj	©÷èlã°Ì2É¦ùqşºä¥*
+endstream
+endobj
+5 0 obj
+<<
+/Type /Page
+/MediaBox [0 0 612 792]
+/Resources <<
+/Font <<
+/F1 7 0 R
+>>
+>>
+/Contents 8 0 R
+/Parent 2 0 R
+>>
+endobj
+9 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [4 0 R 5 0 R]
+/Count 2
+>>
+endobj
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+/Outlines 9 0 R
+>>
+endobj
+3 0 obj
+<<
+/Creator (Soda PDF)
+/CreationDate (D:20060301072826)
+/Producer (Soda PDF)
+/ModDate (D:20201023010744Z)
+>>
+endobj
+xref
+0 10
+0000000000 65535 f
+0000001183 00000 n
+0000001120 00000 n
+0000001248 00000 n
+0000000485 00000 n
+0000000948 00000 n
+0000000112 00000 n
+0000000015 00000 n
+0000000611 00000 n
+0000001074 00000 n
+trailer
+<<
+/Size 10
+/Root 1 0 R
+/Info 3 0 R
+/ID [<ED8FBEC35C8C5CC8AFA14CEB49BA73DE> <A97B73EB6CB3AAD0BE7F7E4D7F67DBD8>]
+>>
+startxref
+1372
+%%EOF

--- a/examples/text.recipe.yml
+++ b/examples/text.recipe.yml
@@ -1,0 +1,8 @@
+- plugin: snowfakery.standard_plugins.file.File
+
+- object: BinaryData
+  fields:
+    encoded_data:
+      - File.file_data:
+          encoding: utf-8
+          file: ../CODE_OF_CONDUCT.md

--- a/snowfakery/standard_plugins/Salesforce.py
+++ b/snowfakery/standard_plugins/Salesforce.py
@@ -69,3 +69,10 @@ class Salesforce(ParserMacroPlugin):
                 )
 
         return sobj, nickname
+
+    def ContentFile(self, context, args) -> ObjectTemplate:
+        return {
+            "Base64.encode": [
+                {"File.file_data": {"encoding": "binary", "file": args.get("path")}}
+            ]
+        }

--- a/snowfakery/standard_plugins/base64.py
+++ b/snowfakery/standard_plugins/base64.py
@@ -1,0 +1,8 @@
+from base64 import b64encode
+from snowfakery.plugins import SnowfakeryPlugin
+
+
+class Base64(SnowfakeryPlugin):
+    class Functions:
+        def encode(self, data):
+            return b64encode(bytes(str(data), "latin1")).decode("ascii")

--- a/snowfakery/standard_plugins/file.py
+++ b/snowfakery/standard_plugins/file.py
@@ -1,0 +1,16 @@
+from snowfakery.plugins import SnowfakeryPlugin
+from pathlib import Path
+
+
+class File(SnowfakeryPlugin):
+    class Functions:
+        def file_data(self, file, encoding):
+            if encoding == "binary":
+                encoding = "latin-1"
+
+            context_filename = Path(
+                self.context.interpreter.current_context.current_template.filename
+            ).parent
+
+            with open(context_filename / file, "rb") as data:
+                return data.read().decode(encoding)

--- a/tests/test_custom_plugins_and_providers.py
+++ b/tests/test_custom_plugins_and_providers.py
@@ -1,6 +1,7 @@
 from io import StringIO
 import math
 import operator
+from base64 import b64decode
 
 from snowfakery.data_generator import generate
 from snowfakery import SnowfakeryPlugin, lazy
@@ -192,6 +193,15 @@ class TestCustomPlugin:
             generate(StringIO(yaml), {}, output_stream)
             output_stream.close()
             assert eval(s.getvalue())[0]["some_value"] == 3
+
+    def test_binary(self, generated_rows):
+        sample = "examples/binary.recipe.yml"
+        with open(sample) as f:
+            generate(f)
+        b64data = generated_rows.table_values("BinaryData", 0)["encoded_data"]
+        rawdata = b64decode(b64data)
+        assert rawdata.startswith(b"%PDF-1.3")
+        assert b"Helvetica" in rawdata
 
 
 class PluginThatNeedsState(SnowfakeryPlugin):

--- a/tests/test_salesforce_gen.py
+++ b/tests/test_salesforce_gen.py
@@ -1,0 +1,13 @@
+from base64 import b64decode
+
+from snowfakery import generate_data
+
+
+class TestSalesforceGen:
+    def test_content_version(self, generated_rows):
+        content_version = "examples/salesforce/ContentVersion.recipe.yml"
+        generate_data(content_version)
+        b64data = generated_rows.table_values("ContentVersion", 0)["VersionData"]
+        rawdata = b64decode(b64data)
+        assert rawdata.startswith(b"%PDF-1.3")
+        assert b"Helvetica" in rawdata


### PR DESCRIPTION
Allow binary or text data to be included and sent to Salesforce. Described in docs.
