### PR TITLE
`pip-tools`: additional fixings

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -8,7 +8,7 @@ pip-tools
 pre-commit
 pytest
 pytest-cov
-Sphinx==3.5.4      # pin this until Myst is happy with Sphinx 4
+Sphinx<4      # pin this until Myst is happy with Sphinx 4
 typeguard==2.10.0   # do not upgrade until #181 is fixed
 faker-microservice
 tox

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,28 @@
+import re
 import setuptools
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 with open("requirements/prod.txt") as requirements_file:
-    requirements = [
-        req.split("#")[0].replace("==", ">=").strip() for req in requirements_file
-    ]
+    requirements = []
+    for req in requirements_file.read().splitlines():
+        # skip comments and hash lines
+        if re.match(r"\s*#", req) or re.match(r"\s*--hash", req):
+            continue
+        else:
+            req = req.split(" ")[0]
+            requirements.append(req)
 
 with open("requirements/dev.txt") as dev_requirements_file:
-    test_requirements = [
-        req.split("#")[0] for req in dev_requirements_file if not req.startswith("-")
-    ]
+    requirements = []
+    for req in requirements_file.read().splitlines():
+        # skip comments and hash lines
+        if re.match(r"\s*#", req) or re.match(r"\s*--hash", req):
+            continue
+        else:
+            req = req.split(" ")[0]
+            requirements.append(req)
 
 # get the version into a global variable named "version"
 with open("snowfakery/version.txt") as f:

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,14 @@ with open("requirements/prod.txt") as requirements_file:
             requirements.append(req)
 
 with open("requirements/dev.txt") as dev_requirements_file:
-    requirements = []
-    for req in requirements_file.read().splitlines():
+    dev_requirements = []
+    for req in dev_requirements_file.read().splitlines():
         # skip comments and hash lines
         if re.match(r"\s*#", req) or re.match(r"\s*--hash", req):
             continue
         else:
             req = req.split(" ")[0]
-            requirements.append(req)
+            dev_requirements.append(req)
 
 # get the version into a global variable named "version"
 with open("snowfakery/version.txt") as f:
@@ -63,6 +63,6 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=requirements,
-    tests_require=test_requirements,
+    tests_require=dev_requirements,
     data_files=[("requirements", ["requirements/prod.txt", "requirements/dev.txt"])],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,29 @@
 import re
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+from typing import List
 
-with open("requirements/prod.txt") as requirements_file:
+
+def parse_requirements_file(requirements_file) -> List[str]:
     requirements = []
     for req in requirements_file.read().splitlines():
         # skip comments and hash lines
         if re.match(r"\s*#", req) or re.match(r"\s*--hash", req):
-            continue
+            return
         else:
             req = req.split(" ")[0]
             requirements.append(req)
+    return requirements
+
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+with open("requirements/prod.txt") as requirements_file:
+    requirements = parse_requirements_file(requirements_file)
 
 with open("requirements/dev.txt") as dev_requirements_file:
-    dev_requirements = []
-    for req in dev_requirements_file.read().splitlines():
-        # skip comments and hash lines
-        if re.match(r"\s*#", req) or re.match(r"\s*--hash", req):
-            continue
-        else:
-            req = req.split(" ")[0]
-            dev_requirements.append(req)
+    dev_requirements = parse_requirements_file(dev_requirements_file)
 
 # get the version into a global variable named "version"
 with open("snowfakery/version.txt") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
 commands = coverage run {envbindir}/pytest []
 
 deps =	
-    -r{toxinidir}/requirements/dev.txt
+    -r{toxinidir}/requirements_dev.txt
 install_command =	
     python -m pip install {opts} {packages}
 


### PR DESCRIPTION
# Changes
* Fixed requirements file to use for dependencies in `tox.ini`
* Fixed parsing of new format of requirements files in setup.py
* Pinned Sphinx to `<4` instead of an exact version.