### PR TITLE
Allow names to use a Salesforce naming convention

### DIFF
--- a/snowfakery/fakedata/fake_data_generator.py
+++ b/snowfakery/fakedata/fake_data_generator.py
@@ -25,6 +25,8 @@ class FakeNames(T.NamedTuple):
         return self.f.email()
 
 
+# we will use this to exclude Faker's internal book-keeping methods
+# from our faker interface
 faker_class_attrs = set(dir(Faker))
 
 

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -173,10 +173,13 @@ class TestFaker:
               fake: PhoneNumber
             pn2:
               fake: phonenumber
+            pn3:
+              fake: phone_number
         """
         generate(StringIO(yaml), {}, None)
-        assert row_values(write_row_mock, 0, "pn1")
-        assert row_values(write_row_mock, 0, "pn2")
+        assert set(row_values(write_row_mock, 0, "pn1")).intersection("0123456789")
+        assert set(row_values(write_row_mock, 0, "pn2")).intersection("0123456789")
+        assert set(row_values(write_row_mock, 0, "pn3")).intersection("0123456789")
 
     @mock.patch(write_row_path)
     def test_faker_kwargs(self, write_row_mock):

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -165,6 +165,20 @@ class TestFaker:
         assert row_values(write_row_mock, 0, "SSN")
 
     @mock.patch(write_row_path)
+    def test_remove_underscores_from_faker(self, write_row_mock):
+        yaml = """
+        - object: A
+          fields:
+            pn1:
+              fake: PhoneNumber
+            pn2:
+              fake: phonenumber
+        """
+        generate(StringIO(yaml), {}, None)
+        assert row_values(write_row_mock, 0, "pn1")
+        assert row_values(write_row_mock, 0, "pn2")
+
+    @mock.patch(write_row_path)
     def test_faker_kwargs(self, write_row_mock):
         yaml = """
         - object: A

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -206,3 +206,14 @@ class TestFaker:
             generate(StringIO(yaml), {}, None)
         assert "xyzzy" in str(e.value)
         assert "fake" in str(e.value)
+
+    def test_faker_internals_are_invisible(self):
+        yaml = """
+        - object: A
+          fields:
+            xyzzy:
+              fake: seed
+        """
+        with pytest.raises(exc.DataGenError) as e:
+            generate(StringIO(yaml), {}, None)
+        assert "seed" in str(e.value)

--- a/tests/test_locales.py
+++ b/tests/test_locales.py
@@ -1,5 +1,6 @@
 from unittest import mock
 from io import StringIO
+from faker import Faker
 
 from snowfakery.data_generator import generate
 
@@ -21,6 +22,12 @@ class TestLocales:
               fake: name
         """
         with mock.patch("snowfakery.utils.template_utils.Faker") as f:
+
+            class FakeFaker(Faker):
+                def name(self):
+                    return "xyzzy"
+
+            f.return_value = FakeFaker()
             generate(StringIO(yaml))
             locale_changes = [c[1][0] for c in f.mock_calls if not c[0]]
 


### PR DESCRIPTION
Allow names to use a Salesforce naming convention: 

phone_number -> PhoneNumber

Alternate spellings are all valid:

phonenumber
PhoneNumber
phone_number (original)
PHONENUMBER

In the unlikely case of there being names ab_cd and abc_d, the caller can use underscores to disambiguate.

