### PR TITLE
Python 3.9 support, especially for math

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -37,13 +37,16 @@ jobs:
           snowbench examples/basic-salesforce.recipe.yml 10_000 Account --number-of-processes 4
 
   windows:
-    name: "Windows"
+    name: Windows ${{ matrix.python-version }}
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.9"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
         with:
-          python-version: "3.8"
+          python-version: "${{ matrix.python-version }}"
 
       - name: "Install dependencies"
         run: |

--- a/examples/math.yml
+++ b/examples/math.yml
@@ -3,3 +3,4 @@
   fields:
     twelve:
       Math.sqrt: ${{Math.min(144, 200)}}
+    pi: ${{Math.pi}}

--- a/snowfakery/standard_plugins/_math.py
+++ b/snowfakery/standard_plugins/_math.py
@@ -1,16 +1,20 @@
-import importlib.util
-
+import math
 from snowfakery.plugins import SnowfakeryPlugin
 
 
 class Math(SnowfakeryPlugin):
     def custom_functions(self, *args, **kwargs):
         "Expose math functions to Snowfakery"
-        mathmodule = importlib.util.find_spec("math")
-        math = importlib.util.module_from_spec(mathmodule)
 
-        math.round = round
-        math.min = min
-        math.max = max
+        class MathNamespace:
+            pass
 
-        return math
+        mathns = MathNamespace()
+        mathns.__dict__ = math.__dict__.copy()
+
+        mathns.pi = math.pi
+        mathns.round = round
+        mathns.min = min
+        mathns.max = max
+
+        return mathns

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py36, py37, py38, coverage-report
+envlist = lint, py36, py37, py38, py39, coverage-report
 
 [testenv]
 setenv =
@@ -17,6 +17,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv:lint]
 description = Run all pre-commit hooks.


### PR DESCRIPTION
Works around Python issue and adds Python 3.9 to Ubuntu and Windows test matrices.