### PR TITLE
Plugins have access to file paths

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -114,7 +114,9 @@ class PluginThatCounts(SnowfakeryPlugin):
 ```
 
 Plugins also have access to a dictionary called `self.context.field_vars()` which
-represents the values that would be available to a formula running in the same context.
+represents the values that would be available to a formula running in the same context
+and `self.context.current_filename` which is the filename of the YAML file being
+processed.
 
 Plugins can return normal Python primitive types, `datetime.date`, `ObjectRow` or `PluginResult` objects. `ObjectRow` objects represent new output records/objects. `PluginResult` objects
 expose a namespace that other code can access through dot-notation. `PluginResult` instances can be

--- a/snowfakery/plugins.py
+++ b/snowfakery/plugins.py
@@ -119,6 +119,10 @@ class PluginContext:
         else:
             raise f"Cannot simplify {field_definition}. Perhaps should have used evaluate_raw?"
 
+    @property
+    def current_filename(self):
+        return self.interpreter.current_context.current_template.filename
+
 
 def lazy(func: Any) -> Callable:
     """A lazy function is one that expects its arguments to be unparsed"""

--- a/snowfakery/standard_plugins/file.py
+++ b/snowfakery/standard_plugins/file.py
@@ -8,9 +8,7 @@ class File(SnowfakeryPlugin):
             if encoding == "binary":
                 encoding = "latin-1"
 
-            context_filename = Path(
-                self.context.interpreter.current_context.current_template.filename
-            ).parent
+            template_path = Path(self.context.current_filename).parent
 
-            with open(context_filename / file, "rb") as data:
+            with open(template_path / file, "rb") as data:
                 return data.read().decode(encoding)


### PR DESCRIPTION
Some plugins need to deal with relative paths and therefore they need to know the filename of the parent, to know what their values are relative to.

Existing test cover this code and upcoming PRs will exercise it as well.