### PR TITLE
Pin a version to make VCR happy.

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,6 +1,8 @@
 minimum_cumulusci_version: "3.16.0"
 project:
     name: Snowfakery
+    package:
+        api_version: "50.0"
     dependencies:
         - github: https://github.com/SalesforceFoundation/NPSP
 


### PR DESCRIPTION
VCR has recorded API calls with version 50.0. Salesforce is now delivering 52.0 orgs.

The place where I would add some magic to make it work without pinning is in CCI, not Snowfakery, so this is a workaround until I can fix it better in CCI.
