### PR TITLE
Support all relevant mapping features in load.yml

### DIFF
--- a/snowfakery/cci_mapping_files/declaration_parser.py
+++ b/snowfakery/cci_mapping_files/declaration_parser.py
@@ -28,7 +28,7 @@ class AtomicDecl(T.NamedTuple):
 
     sf_object: str
     key: str
-    value: T.Union[T.List, str]
+    value: T.Union[T.List, str, date, int]
     priority: int
     merge_rule: T.Callable  # what to do if two declarations for same val
 
@@ -87,7 +87,12 @@ class SObjectRuleDeclaration(BaseModel):
             return val
 
     def as_mapping(self):
-        rc = {"api": self.api, "bulk_mode": self.bulk_mode}
+        rc = {
+            "api": self.api,
+            "bulk_mode": self.bulk_mode,
+            "batch_size": self.batch_size,
+            "anchor_date": self.anchor_date,
+        }
         return {k: v for k, v in rc.items() if v is not None}
 
 

--- a/tests/cci/mapping_mixins.load.yml
+++ b/tests/cci/mapping_mixins.load.yml
@@ -6,4 +6,6 @@
   api: rest
 
 - sf_object: Account
-  api: smart
+  api: rest
+  batch_size: 100
+  anchor_date: 2000-01-01

--- a/tests/cci/test_declaration_parser.py
+++ b/tests/cci/test_declaration_parser.py
@@ -21,6 +21,8 @@ declarations = [
     SObjectRuleDeclaration(sf_object="bar", priority="medium", api="smart"),
     SObjectRuleDeclaration(sf_object="bar", priority="medium", bulk_mode="serial"),
     SObjectRuleDeclaration(sf_object="bar", priority="high", bulk_mode="Parallel"),
+    SObjectRuleDeclaration(sf_object="foo", priority="low", batch_size=2000),
+    SObjectRuleDeclaration(sf_object="foo", priority="low", anchor_date="2000-01-01"),
 ]
 
 
@@ -42,9 +44,9 @@ class TestDeclarationParser:
                 load_after=None,
                 priority=None,
                 api="bulk",
-                batch_size=None,
+                batch_size=2000,
                 bulk_mode="serial",
-                anchor_date=None,
+                anchor_date="2000-01-01",
             ),
         }
 
@@ -74,7 +76,7 @@ class TestDeclarationParser:
             "Insert Contact",
             "Insert Opportunity",
         ]
-        assert map_data["Insert Account"]["api"] == "smart"
+        assert map_data["Insert Account"]["api"] == "rest"
 
     def test_cli__explicit_file(self, tmpdir):
         sample_yaml = Path(__file__).parent / "mapping_mixins.recipe.yml"


### PR DESCRIPTION
Snowfakery-in-CCI now allows users to set the batch_size and anchor_date for dataloads.