### PR TITLE
Parent child just once bugfix

### DIFF
--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -83,6 +83,13 @@ class Transients:
     def first_new_id(self, tablename):
         return self.orig_used_ids.get(tablename, 0) + 1
 
+    def last_id_for_table(self, tablename):
+        last_obj = self.last_seen_obj_by_table.get(tablename)
+        if last_obj:
+            return last_obj.id
+        else:
+            return self.orig_used_ids.get(tablename)
+
 
 class Globals:
     """Globally named objects and other aspects of global scope
@@ -129,8 +136,7 @@ class Globals:
                 self.transients.nicknamed_objects[nickname] = obj
         if persistent_object:
             self.persistent_objects_by_table[obj._tablename] = obj
-        else:
-            self.transients.last_seen_obj_by_table[obj._tablename] = obj
+        self.transients.last_seen_obj_by_table[obj._tablename] = obj
 
     @property
     def object_names(self):

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -333,7 +333,7 @@ class StructuredValue(FieldDefinition):
                 )
 
             with self.exception_handling(
-                "Cannot evaluate function `{}`:\n {e}", self.function_name
+                "Cannot evaluate function `{}`:\n {e}", [self.function_name]
             ):
                 value = evaluate_function(func, self.args, self.kwargs, context)
 

--- a/snowfakery/standard_plugins/Salesforce.py
+++ b/snowfakery/standard_plugins/Salesforce.py
@@ -330,6 +330,9 @@ class Salesforce(ParserMacroPlugin, SnowfakeryPlugin, SalesforceConnectionMixin)
 
 # TODO: Tests for this class
 class SOQLDatasetImpl(DatasetBase):
+    iterator = None
+    tempdir = None
+
     def __init__(self, plugin, *args, **kwargs):
         from cumulusci.tasks.bulkdata.step import (
             get_query_operation,

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -254,14 +254,14 @@ class StandardFuncs(SnowfakeryPlugin):
             """
 
             globls = self.context.interpreter.globals
-            last_object = globls.transients.last_seen_obj_by_table.get(tablename)
-            if last_object:
-                last_id = last_object.id
+            last_id = globls.transients.last_id_for_table(tablename)
+            if last_id:
                 if scope == "prior-and-current-iterations":
                     first_id = 1
                     warnings.warn("Global scope is an experimental feature.")
                 elif scope == "current-iteration":
                     first_id = globls.first_new_id(tablename)
+                    last_id = max(first_id, last_id)
                 else:
                     raise DataGenError(
                         f"Scope must be 'prior-and-current-iterations' or 'current-iteration' not {scope}",

--- a/tests/parent-child-just-once.yml
+++ b/tests/parent-child-just-once.yml
@@ -1,0 +1,11 @@
+- object: Parent
+  just_once: true
+  nickname: ParentNickname
+
+- object: Child
+  fields:
+    parent:
+      random_reference: Parent
+  # should fail:
+  # parent2:
+  #   random_reference: ParentNickname

--- a/tests/test_continuation.py
+++ b/tests/test_continuation.py
@@ -4,7 +4,7 @@ from io import StringIO
 from snowfakery.data_generator import generate
 
 
-class TestRestart:
+class TestContinuation:
     def test_nicknames_persist(self, generated_rows):
         yaml = """
             - object: foo
@@ -103,3 +103,27 @@ class TestRestart:
             StringIO(yaml_data),
             continuation_file=StringIO(continuation_yaml),
         )
+
+    def test_reference_just_once(self, generated_rows):
+        yaml_data = """
+                        - object: Parent
+                          just_once: true
+
+                        - object: Child
+                          fields:
+                            parent:
+                                random_reference: Parent
+                            """
+        generate_twice(yaml_data)
+        assert generated_rows()
+
+
+def generate_twice(yaml):
+    continuation_file = StringIO()
+    generate(StringIO(yaml), generate_continuation_file=continuation_file)
+    next_contination_file = StringIO()
+    generate(
+        StringIO(yaml),
+        continuation_file=StringIO(continuation_file.getvalue()),
+        generate_continuation_file=next_contination_file,
+    )

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -490,3 +490,31 @@ class TestReferences:
         with pytest.raises(DataGenError) as e:
             generate(StringIO(yaml))
         assert "can't get reference to object" in str(e).lower()
+
+    def test_random_reference_to_just_once_obj(self):
+        yaml = """
+              - object: Parent
+                just_once: true
+
+              - object: Child
+                fields:
+                  parent:
+                    random_reference: Parent
+
+                """
+        generate(StringIO(yaml))
+
+    def test_random_reference_to_nickname_fails(self):
+        yaml = """
+              - object: Parent
+                nickname: ParentNickname
+                just_once: true
+
+              - object: Child
+                fields:
+                  parent:
+                    random_reference: Parent
+                """
+        with pytest.raises(DataGenError) as e:
+            generate(StringIO(yaml))
+        assert "there is no table named parent" in str(e).lower()

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -491,7 +491,7 @@ class TestReferences:
             generate(StringIO(yaml))
         assert "can't get reference to object" in str(e).lower()
 
-    def test_random_reference_to_just_once_obj(self):
+    def test_random_reference_to_just_once_obj(self, generated_rows):
         yaml = """
               - object: Parent
                 just_once: true
@@ -500,9 +500,9 @@ class TestReferences:
                 fields:
                   parent:
                     random_reference: Parent
-
                 """
-        generate(StringIO(yaml))
+        generate(StringIO(yaml), stopping_criteria=StoppingCriteria("Child", 2))
+        assert len(generated_rows.mock_calls) == 3
 
     def test_random_reference_to_nickname_fails(self):
         yaml = """
@@ -513,7 +513,7 @@ class TestReferences:
               - object: Child
                 fields:
                   parent:
-                    random_reference: Parent
+                    random_reference: ParentNickname
                 """
         with pytest.raises(DataGenError) as e:
             generate(StringIO(yaml))


### PR DESCRIPTION
Previously, the `random_reference` feature could not refer to objects created with just_once.  This has been corrected.