### PR TITLE
Allow bools and dates as options for random_choice's short syntax

### DIFF
--- a/snowfakery/parse_recipe_yaml.py
+++ b/snowfakery/parse_recipe_yaml.py
@@ -147,7 +147,6 @@ def removeline_numbers(dct: Dict) -> Dict:
 
 
 def _coerce_to_string(val, context):
-    print(val, type(val))
     if isinstance(val, str):
         return val
     elif isinstance(val, (int, bool, date)):

--- a/snowfakery/parse_recipe_yaml.py
+++ b/snowfakery/parse_recipe_yaml.py
@@ -146,14 +146,34 @@ def removeline_numbers(dct: Dict) -> Dict:
     return {i: dct[i] for i in dct if i != "__line__"}
 
 
+def _coerce_to_string(val, context):
+    print(val, type(val))
+    if isinstance(val, str):
+        return val
+    elif isinstance(val, (int, bool, date)):
+        # a few functions accept keyword arguments that YAML interprets
+        # as types other than string
+        return str(val)
+    else:
+        if val is None:
+            val = "null (None)"
+        raise exc.DataGenSyntaxError(
+            f"Cannot interpret key `{val}`` as string", **context.line_num()
+        )
+
+
 def parse_structured_value_args(
     args, context: ParseContext
 ) -> Union[List, Dict, SimpleValue, StructuredValue, ObjectTemplate]:
     """Structured values can be dicts or lists containing simple values or further structure."""
     if isinstance(args, dict):
+
+        def as_str(name):
+            return _coerce_to_string(name, context)
+
         with context.change_current_parent_object(args):
             return {
-                name: parse_field_value(name, arg, context, False)
+                as_str(name): parse_field_value(as_str(name), arg, context, False)
                 for name, arg in args.items()
                 if name != "__line__"
             }

--- a/tests/bad_random_choice_keys.yml
+++ b/tests/bad_random_choice_keys.yml
@@ -1,0 +1,5 @@
+- object: foo
+  fields:
+    bar:
+      random_choice:
+        null: 10%

--- a/tests/random_choice.yml
+++ b/tests/random_choice.yml
@@ -1,0 +1,10 @@
+- object: foo
+  fields:
+    bool:
+      random_choice:
+        true: 15%
+        false: 85%
+    date:
+      random_choice:
+        1999-12-31: 99% # party time!
+        2012-01-01: 1% # end of the world!

--- a/tests/test_custom_plugins_and_providers.py
+++ b/tests/test_custom_plugins_and_providers.py
@@ -90,6 +90,14 @@ class EvalPlugin(SnowfakeryPlugin):
             )
 
 
+class DoesNotClosePlugin(SnowfakeryPlugin):
+    close = NotImplemented
+
+    class Functions:
+        def foo(self, a=None):
+            return None
+
+
 class TestCustomFakerProvider:
     @mock.patch(write_row_path)
     def test_custom_faker_provider(self, write_row_mock):
@@ -336,3 +344,14 @@ class TestContextVars:
         with pytest.raises(DataGenError) as e:
             generate_data(StringIO(yaml))
         assert 6 > e.value.line_num >= 3
+
+    def test_plugin_does_not_close(self):
+        yaml = """
+        - plugin: tests.test_custom_plugins_and_providers.DoesNotClosePlugin
+        - object: B
+          fields:
+            foo:
+                DoesNotClosePlugin.foo:
+        """
+        with pytest.warns(UserWarning, match="close"):
+            generate_data(StringIO(yaml))

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -1,5 +1,8 @@
 from io import StringIO
 from unittest import mock
+import pydantic
+import datetime
+
 
 from snowfakery.data_generator import generate
 from snowfakery.data_gen_exceptions import DataGenError
@@ -405,3 +408,21 @@ class TestTemplateFuncs:
                 {"id": 5, "EndDate": 1, "DateSupplied": "Yes"},
             ),
         ]
+
+    def test_random_choice_nonstring_keys(self, generated_rows):
+        with open("tests/random_choice.yml") as yaml:
+            generate(yaml)
+        result = generated_rows.table_values("foo", 0)
+
+        class ResultModel(pydantic.BaseModel):
+            id: int
+            bool: bool
+            date: datetime.date
+
+        assert ResultModel(**result)
+
+    def test_random_choice_wrong_type_keys(self, generated_rows):
+        with open("tests/bad_random_choice_keys.yml") as yaml:
+            with pytest.raises(DataGenError) as e:
+                generate(yaml)
+        assert "null" in str(e.value)


### PR DESCRIPTION
random_choice has a short-form key:probability syntax. Now that short-form syntax can be used for booleans and dates, not just strings.
