### PR TITLE
Add a test for properly closing datasets

### DIFF
--- a/tests/test_external_datasets.py
+++ b/tests/test_external_datasets.py
@@ -239,3 +239,11 @@ class TestExternalDatasets:
             generate(StringIO(yaml), {})
 
         assert "multiple tables in it" in str(e.value)
+
+    def test_datasets_example(self, capsys, caplog):
+        with open(
+            Path(__file__).parent.parent / "examples/datasets/datasets.recipe.yml"
+        ) as f:
+            generate(f, {})
+            assert capsys.readouterr().err == ""
+            assert caplog.text == ""


### PR DESCRIPTION
Datasets can output warnings if they don't close properly. This test checks that they DO close properly and DO NOT output warnings.