### PR TITLE
Improve test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -105,7 +105,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.6", "3.10"]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v1"
@@ -117,6 +117,10 @@ jobs:
           python -VV
           python -m pip install --upgrade pip
           make dev-install
+          # Snowfakery should work both with and without graphviz.
+          # On Linux we test without it and on Windows we test with it.
+          # The Unit tests adapt to both situations
+          choco install graphviz
 
       - name: Run Tests
         run: python -m pytest

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -109,6 +109,30 @@ def graphviz_available():
 
 
 class TestImageOuputStreams:
+    @mock.patch("subprocess.Popen")
+    def test_image_outputs_mocked(self, popen):
+        png = "out.png"
+        svg = "out.svg"
+        txt = "out.txt"
+        dot = "out.dot"
+        popen.return_value.communicate = lambda: (mock.Mock(), mock.Mock())
+        generate_cli.main(
+            [
+                str(sample_yaml),
+                "--output-file",
+                png,
+                "--output-file",
+                svg,
+                "--output-file",
+                txt,
+                "--output-file",
+                dot,
+            ],
+            standalone_mode=False,
+        )
+        for call in popen.mock_calls:
+            assert call[1][0][0] == "dot"
+
     def test_image_outputs(self):
         if not graphviz_available():
             pytest.skip("Graphviz is not installed")


### PR DESCRIPTION
1. Include Python 3.10
2. Install graphviz in some test contexts to check that it is properly invoked
3. Test a mocked version of image processing in all contexts.