### PR TITLE
Allow zero-prefixed strings of digits

### DIFF
--- a/snowfakery/utils/template_utils.py
+++ b/snowfakery/utils/template_utils.py
@@ -66,7 +66,7 @@ number_chars = set(string.digits + ".")
 
 def look_for_number(arg):
     looks_like_float = False
-    if len(arg) == 0 or arg[0] == "0":
+    if len(arg) == 0 or (arg[0] == "0" and arg[1:2] != "."):
         return arg
     for char in arg:
         if char not in number_chars:

--- a/snowfakery/utils/template_utils.py
+++ b/snowfakery/utils/template_utils.py
@@ -66,7 +66,7 @@ number_chars = set(string.digits + ".")
 
 def look_for_number(arg):
     looks_like_float = False
-    if len(arg) == 0:
+    if len(arg) == 0 or arg[0] == "0":
         return arg
     for char in arg:
         if char not in number_chars:

--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -5,11 +5,11 @@ class TestParseNumbers:
     def test_parse_int(self):
         assert look_for_number("7") == 7
         assert look_for_number("7") != "7"
-        assert look_for_number("09") == 9
+        assert look_for_number("09") == "09"
 
     def test_parse_float(self):
         assert look_for_number("7.3") == 7.3
-        assert look_for_number("09.9") == 9.9
+        assert look_for_number("09.9") == "09.9"
 
     def test_do_not_parse_phone_number(self):
         assert look_for_number("117.344.3333") == "117.344.3333"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,7 @@ from io import StringIO
 from snowfakery.data_generator import generate
 
 
-class TestGenerateMapping:
+class TestTypes:
     @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
     def test_empty_string(self, write_row):
         yaml = """
@@ -13,4 +13,15 @@ class TestGenerateMapping:
                 bar: ""
         """
         generate(StringIO(yaml))
-        print(write_row.mock_calls[0][1][1]["bar"] == "")
+        assert write_row.mock_calls[0][1][1]["bar"] == ""
+
+    def test_zero_prefixed_string(self, generated_rows):
+        yaml = """
+            - object: Foo
+              fields:
+                bar: "012345"
+                bar2: ${{"012345"}}
+        """
+        generate(StringIO(yaml))
+        assert generated_rows.row_values(0, "bar") == "012345"
+        assert generated_rows.row_values(0, "bar2") == "012345"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -25,3 +25,14 @@ class TestTypes:
         generate(StringIO(yaml))
         assert generated_rows.row_values(0, "bar") == "012345"
         assert generated_rows.row_values(0, "bar2") == "012345"
+
+    def test_float(self, generated_rows):
+        yaml = """
+            - object: Foo
+              fields:
+                foo: 0.1
+                foo2: ${{0.1}}
+        """
+        generate(StringIO(yaml))
+        assert generated_rows.row_values(0, "foo") == 0.1
+        assert generated_rows.row_values(0, "foo2") == 0.1


### PR DESCRIPTION
Snowfakery infers integers from digit strings in Jinja templates. The old pattern would strip leading zeros from digit strings starting with 0. (01234 => 1234). This is especially problematic for US postal codes as discovered in #479.

This patch leaves 0-prefixed strings as strings.
