### PR TITLE
Limit usernames to 80 chars

### DIFF
--- a/snowfakery/fakedata/fake_data_generator.py
+++ b/snowfakery/fakedata/fake_data_generator.py
@@ -31,10 +31,16 @@ class FakeNames(T.NamedTuple):
     # need to.
     def user_name(self, matching: bool = True):
         "Salesforce-style username in the form of an email address"
+        domain = self.f.hostname()
         already_created = self._already_have(("firstname", "lastname"))
         if matching and all(already_created):
-            return f"{already_created[0]}.{already_created[1]}_{self.f.uuid4()}@{self.f.safe_domain_name()}"
-        return f"{self.f.first_name()}_{self.f.last_name()}_{self.f.uuid4()}@{self.f.hostname()}"
+            namepart = f"{already_created[0]}.{already_created[1]}_{self.f.uuid4()}"
+        else:
+            namepart = f"{self.f.first_name()}_{self.f.last_name()}_{self.f.uuid4()}"
+
+        namepart_max_len = 80 - (len(domain) + 1)
+        namepart = namepart[0:namepart_max_len]
+        return f"{namepart}@{domain}"
 
     def alias(self):
         """Salesforce-style 8-character alias: really an 8 char-truncated firstname.

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -375,3 +375,18 @@ class TestFaker:
         generate(StringIO(yaml))
         assert first_name.mock_calls
         assert email.mock_calls
+
+    @mock.patch("faker.providers.person.en_US.Provider.first_name")
+    def test_username_length_limit(self, first_name, generated_rows):
+        yaml = """
+            - object: X
+              fields:
+                UserName:
+                  fake: UserName
+            """
+        first_name.return_value = "A" * 100
+
+        generate(StringIO(yaml))
+        assert len(generated_rows.row_values(0, "UserName")) == 80, len(
+            generated_rows.row_values(0, "UserName")
+        )


### PR DESCRIPTION
Usernames are now limited to 80 chars to match Salesforce rules.

Fixes #546 . Thanks for reporting, @mirvinecx1
