### PR TITLE
Do not search locales and do not document "fake: zipfile" and similar irrelevant fakers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,10 @@ markdown_extensions:
       toc_depth: 4
 plugins:
   - search
+  - exclude-search:
+      exclude:
+        - docs/fakedata/*.md
+        - fakedata/*.md
   - snowfakery_fakes:
       build_locales: True # do generate locales
       # set SF_MKDOCS_BUILD_LOCALES to overide

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,6 +4,7 @@ coverage
 coveralls
 flake8
 mkdocs
+mkdocs-exclude-search
 pre-commit
 pytest
 pytest-cov

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -95,6 +95,8 @@ markupsafe==2.0.1
     #   jinja2
 mccabe==0.6.1
     # via flake8
+mkdocs-exclude-search==0.5.4
+    # via -r requirements/dev.in
 mergedeep==1.3.4
     # via mkdocs
 mkdocs==1.2.3

--- a/tools/faker_docs_utils/docs_config.yml
+++ b/tools/faker_docs_utils/docs_config.yml
@@ -197,3 +197,7 @@ uncommon_fakes:
   building_number:
   country_code:
   current_country_code:
+ignore:
+  - Tar
+  - Sha256
+  - Zip

--- a/tools/faker_docs_utils/summarize_fakers.py
+++ b/tools/faker_docs_utils/summarize_fakers.py
@@ -26,10 +26,11 @@ def summarize_all_fakers(faker) -> T.Sequence[FakerInfo]:
         yaml_data = yaml.safe_load(f)
         common_fakes = yaml_data["common_fakes"]
         uncommon_fakes = yaml_data["uncommon_fakes"]
+        ignorables = [name.lower() for name in yaml_data["ignore"]]
 
     faker_infos = CaseInsensitiveDict()
     for name, meth in faker.fake_names.items():
-        if not isinstance(meth, types.MethodType):
+        if not isinstance(meth, types.MethodType) or name.lower() in ignorables:
             continue
         # python magic to introspect classnames, filenames, etc.
         friendly = _to_camel_case(name)


### PR DESCRIPTION
There are two things in this branch:

1. Config for mkdocs search index build to prevent extremely slow searching:
    https://snowfakery.readthedocs.io/en/latest/search.html?q=postcode
versus:
    https://snowfakery.readthedocs.io/en/feature-dont-search-locales/search.html?q=postcode

2. While I was researching I noticed that the index is bloated by Fake data for things like "fake tarfile", "take zipfile" etc. Now I have a feature for ignoring those.

