### PR TITLE
Allow parent applications to create output streams and fix datetime

### DIFF
--- a/snowfakery/api.py
+++ b/snowfakery/api.py
@@ -114,6 +114,12 @@ class SnowfakeryApplication:
 
         return last_used_id >= target_id
 
+    def configure_output_stream(
+        self,
+        **kwargs,
+    ):
+        return configure_output_stream(parent_application=self, **kwargs)
+
 
 def stopping_criteria_from_target_number(target_number):
     "Deconstruct a tuple of 'str number' or 'number str' and make a StoppingCriteria"
@@ -163,12 +169,15 @@ def generate_data(
             return exit_stack.enter_context(open_file_like(file, mode))
 
         parent_application = parent_application or SnowfakeryApplication(
-            stopping_criteria
+            stopping_criteria,
         )
 
         output_stream = exit_stack.enter_context(
-            configure_output_stream(
-                dburls, output_format, output_files, output_folder, parent_application
+            parent_application.configure_output_stream(
+                dburls=dburls,
+                output_format=output_format,
+                output_files=output_files,
+                output_folder=output_folder,
             )
         )
 

--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -16,7 +16,7 @@ from .template_funcs import StandardFuncs
 from .data_gen_exceptions import DataGenSyntaxError, DataGenNameError
 import snowfakery  # noQA
 from snowfakery.object_rows import NicknameSlot, SlotState, ObjectRow
-from snowfakery.plugins import PluginContext, SnowfakeryPlugin
+from snowfakery.plugins import PluginContext, SnowfakeryPlugin, Scalar
 from snowfakery.utils.collections import OrderedSet
 
 OutputStream = "snowfakery.output_streams.OutputStream"
@@ -569,7 +569,11 @@ class EvaluationNamespace(NamedTuple):
         return {**self.field_funcs(), "fake": self.fake}
 
     def fake(self, name):
-        return str(self.runtime_context.faker_template_library._get_fake_data(name))
+        val = self.runtime_context.faker_template_library._get_fake_data(name)
+        if isinstance(val, Scalar.__args__):
+            return val
+        else:
+            return str(val)
 
     def field_vars(self):
         return {**self.simple_field_vars(), **self.field_funcs()}

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 from collections import namedtuple, defaultdict
 from typing import Dict, Union, Optional, Mapping, Callable, Sequence
-from warnings import warn
 
 from sqlalchemy import (
     create_engine,
@@ -125,7 +124,7 @@ class OutputStream(ABC):
 
         Return a list of messages to print out.
         """
-        return super().close()
+        pass
 
     def __enter__(self, *args):
         return self
@@ -278,9 +277,7 @@ class SqlDbOutputStream(OutputStream):
 
     should_close_session = False
 
-    def __init__(self, engine: Engine, mappings: None = None, **kwargs):
-        if mappings:
-            warn("Please do not pass mappings argument to __init__", DeprecationWarning)
+    def __init__(self, engine: Engine, **kwargs):
         self.buffered_rows = defaultdict(list)
         self.table_info = {}
         self.engine = engine
@@ -289,9 +286,7 @@ class SqlDbOutputStream(OutputStream):
         self.base = automap_base(bind=engine, metadata=self.metadata)
 
     @classmethod
-    def from_url(cls, db_url: str, mappings: None = None):
-        if mappings:
-            warn("Please do not pass mappings argument to from_url", DeprecationWarning)
+    def from_url(cls, db_url: str):
         engine = create_engine(db_url)
         self = cls(engine)
         return self


### PR DESCRIPTION
When Snowfakery is embedded in CumulusCI it needs to format data slightly differently because Salesforce requires date-times to have a timezone. This puts the parent application (like CumulusCI) in charge of supplying OutputStreams, so it can capture information however it wants. Perhaps one day CumulusCI will be able to start sending data to Salesforce before Snowfakery has finished executing even a single iteration of the recipe.

Comments explain the changes.

Note for HISTORY.rst: recipes that depended on fakers always being serialized to strings will need to do it explicitly now.