### PR TITLE
Remove some function calls on a hot code path

### DIFF
--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -267,8 +267,6 @@ class JinjaTemplateEvaluatorFactory:
                 return lambda context: template.render(context.field_vars())
             except jinja2.exceptions.TemplateSyntaxError as e:
                 raise DataGenSyntaxError(str(e)) from e
-        else:
-            return lambda context: definition
 
 
 class Interpreter:
@@ -423,7 +421,6 @@ class RuntimeContext:
     but internally its mostly just proxying to other classes."""
 
     obj: Optional[ObjectRow] = None
-    template_evaluator_recipe = JinjaTemplateEvaluatorFactory()
     current_template = None
     local_vars = None
     unique_context_identifier = None
@@ -510,9 +507,6 @@ class RuntimeContext:
     @property
     def output_stream(self):
         return self.interpreter.output_stream
-
-    def get_evaluator(self, definition: str):
-        return self.template_evaluator_recipe.get_evaluator(definition)
 
     @property
     def evaluation_namespace(self):

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -323,7 +323,8 @@ class SimpleValue(FieldDefinition):
         self.setup_evaluator()
 
     def setup_evaluator(self):
-        """Populate the evaluator property once."""
+        """Populate the evaluator property once, if and only if this field
+        contains Jinja syntax."""
         self._evaluator = None
         if isinstance(self.definition, str):
             with self.exception_handling("Cannot parse value {}", self.definition):


### PR DESCRIPTION
Centralize all of the code for evaluating extremely simple expressions like:

field:
    A: blah

This used to be treated as a special case of 

field:
    A: ${{blah}}

where the string evaluates to itself because it has no executable code in it. Instead, it now detects the simple case very early and bypasses all of the logic that treats it as an executable expression.

Evaluation of simple fields is at least 6% faster and probably much more.