### PR TITLE
Check for case where CSV Row has too many columns

### DIFF
--- a/tests/badcsv_too_many_columns.csv
+++ b/tests/badcsv_too_many_columns.csv
@@ -1,0 +1,5 @@
+id,FirstName,LastName
+0032D00000V6UvUQAV,Michael,Bluth,32252 Marc Mall Suite 349,South Kristenview,Massachusetts,65450,United States
+032D00000V6UvVQAV,Isabella,Wright,41497 Henson Motorway,West Marisaland,Alaska,10293,United States
+032D00000V6UvfQAF,Desiree,Shelton,84504 Darren Knolls Suite 023,Port Sandra,Pennsylvania,68863,United States
+032D00000V6UvkQAF,Deanna,Mcdaniel,838 Montoya Circle Apt. 857,West Robert,Louisiana,03074,United States

--- a/tests/test_external_datasets.py
+++ b/tests/test_external_datasets.py
@@ -187,6 +187,24 @@ class TestExternalDatasets:
             generate(StringIO(yaml), {})
         assert "'xname ', 'fake'" in str(e.value)
 
+    def test_csv_row_has_too_many_columns(self):
+        abs_path = str(Path(__file__).parent)
+        yaml = (
+            """
+        - plugin: snowfakery.standard_plugins.datasets.Dataset
+        - object: XXX
+          fields:
+            __address_from_csv:
+              Dataset.iterate:
+                dataset: %s/badcsv_too_many_columns.csv
+            foo: ${{__address_from_csv.name}}
+        """
+            % abs_path
+        )
+        with pytest.raises(exc.DataGenError) as e:
+            generate(StringIO(yaml), {})
+        assert "more columns" in str(e.value)
+
     def test_csv_utf_8_bom(self, generated_rows):
         abs_path = Path(__file__).parent
         yaml = (


### PR DESCRIPTION
Better error checking for the case where a CSV Row has too many columns.