### PR TITLE
datetime() function should behave like faker w.r.t timezones

### DIFF
--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -18,6 +18,7 @@ from snowfakery.plugins import SnowfakeryPlugin, PluginContext, lazy
 from snowfakery.object_rows import ObjectReference
 from snowfakery.utils.template_utils import StringGenerator
 from snowfakery.standard_plugins.UniqueId import UniqueId
+from snowfakery.fakedata.fake_data_generator import UTCAsRelDelta, _normalize_timezone
 
 FieldDefinition = "snowfakery.data_generator_runtime_object_model.FieldDefinition"
 
@@ -103,9 +104,13 @@ class StandardFuncs(SnowfakeryPlugin):
             minute=0,
             second=0,
             microsecond=0,
+            timezone=UTCAsRelDelta,
         ):
             """A YAML-embeddable function to construct a datetime from strings or integers"""
-            return datetime(year, month, day, hour, minute, second, microsecond)
+            timezone = _normalize_timezone(timezone)
+            return datetime(
+                year, month, day, hour, minute, second, microsecond, tzinfo=timezone
+            )
 
         def date_between(self, *, start_date, end_date):
             """A YAML-embeddable function to pick a date between two ranges"""

--- a/tests/test_datetimes.yml
+++ b/tests/test_datetimes.yml
@@ -65,3 +65,26 @@
     LastName:
       fake: LastName
     EmailBouncedDate: ${{fake.iso8601(timezone=False)}}Z
+
+- object: Contact
+  fields:
+    LastName:
+      fake: LastName
+    EmailBouncedDate:
+      datetime:
+        year: 2000
+        month: 1
+        day: 1
+
+- object: Contact
+  fields:
+    LastName:
+      fake: LastName
+    EmailBouncedDate:
+      datetime:
+        year: 2000
+        month: 1
+        day: 1
+        timezone:
+          relativedelta:
+            hours: 8

--- a/tests/test_output_streams.py
+++ b/tests/test_output_streams.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from io import StringIO
 import json
 import datetime
+from datetime import timezone
 import csv
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -56,9 +57,16 @@ class OutputCommonTests(ABC):
         assert values["y2k"] == str(datetime.date(year=2000, month=1, day=1))
         assert values["party"] == str(
             datetime.datetime(
-                year=1999, month=12, day=31, hour=23, minute=59, second=59
+                year=1999,
+                month=12,
+                day=31,
+                hour=23,
+                minute=59,
+                second=59,
+                tzinfo=timezone.utc,
             )
         )
+
         assert len(values["randodate"].split("-")) == 3
         assert values["randodate"].startswith("200")
 


### PR DESCRIPTION
datetime() function will now behave like the fake data providers w.r.t timezones

Extension of:

https://github.com/SFDO-Tooling/Snowfakery/pull/601

I forgot this part.