### PR TITLE
Add a debug function to Snowfakery.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -782,6 +782,10 @@ Macros can include other macros. In fact, macros are especially powerful if you 
 .. note::
 `fields` or `friends` declared in the macros listed later override those listed earlier. `fields` or `friends` declared in the Object Template override those declared in macros.
 
+### Debug
+
+The `debug` function can be used to output values to your command line for debugging. Specifically, it outputs the value to `stderr`.
+
 ## Define Variables
 
 To generate a value shared by multiple templates, create a variable with `var`.

--- a/snowfakery/template_funcs.py
+++ b/snowfakery/template_funcs.py
@@ -1,3 +1,4 @@
+import sys
 import random
 from functools import lru_cache
 from datetime import date, datetime
@@ -337,6 +338,12 @@ class StandardFuncs(SnowfakeryPlugin):
 
         def _unique_alpha_code(self):
             return self._unique_id_generator.default_alpha_code_generator.unique_id
+
+        def debug(self, *values):
+            sys.stderr.write("DEBUG")
+            sys.stderr.write(repr(values))
+            sys.stderr.write("\n")
+            return values[0]
 
     setattr(Functions, "if", Functions.if_)
     setattr(Functions, "relativedelta", relativedelta)

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -426,3 +426,15 @@ class TestTemplateFuncs:
             with pytest.raises(DataGenError) as e:
                 generate(yaml)
         assert "null" in str(e.value)
+
+    def test_debug(self, capsys):
+        yaml = """
+        - object : A
+          fields:
+            a: ${{debug("XYZZY")}}
+            b: ${{debug(420)}}
+        """
+        generate(StringIO(yaml))
+        stderr = capsys.readouterr().err
+        assert "XYZZY" in stderr
+        assert "420" in stderr


### PR DESCRIPTION
Adds a function for inspecting the value of a Snowfakery value in a recipe.

Might be helpful for debugging recipe issues that arise from the NativeTypes feature.