### PR TITLE
Native types instead of strings

### DIFF
--- a/examples/native_types_differences.yml
+++ b/examples/native_types_differences.yml
@@ -1,0 +1,6 @@
+# snowfakery examples/native_types_differences.yml --plugin-option snowfakery_version 3
+- snowfakery_version: 3
+- object: Example
+  fields:
+    y: ${{datetime(year=2000, month=1, day=1)}}
+    z: ${{y.date()}}

--- a/schema/snowfakery_recipe.jsonschema.json
+++ b/schema/snowfakery_recipe.jsonschema.json
@@ -23,6 +23,9 @@
       },
       {
         "$ref": "#/$defs/option"
+      },
+      {
+        "$ref": "#/$defs/version"
       }
     ]
   },
@@ -226,10 +229,20 @@
             ]
           }
         }
+      }
+    },
+    "version": {
+      "title": "Version Declaration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "snowfakery_version": {
+          "description": "The Snowfakery version",
+          "type": "integer",
+          "enum": [2, 3]
+        }
       },
-      "required": [
-        "macro"
-      ]
+      "required": ["snowfakery_version"]
     }
   }
 }

--- a/snowfakery/data_generator.py
+++ b/snowfakery/data_generator.py
@@ -7,6 +7,8 @@ import yaml
 from faker.providers import BaseProvider as FakerProvider
 from click.utils import LazyFile
 
+from snowfakery.standard_plugins.SnowfakeryVersion import SnowfakeryVersion
+
 from .data_gen_exceptions import DataGenNameError
 from .output_streams import DebugOutputStream, OutputStream
 from .parse_recipe_yaml import parse_recipe
@@ -143,8 +145,12 @@ def generate(
     faker_providers, snowfakery_plugins = process_plugins(parse_result.plugins)
 
     snowfakery_plugins.setdefault("UniqueId", UniqueId)
+    snowfakery_plugins.setdefault("SnowfakeryVersion", SnowfakeryVersion)
+    plugin_options = plugin_options or {}
+    if parse_result.version:
+        plugin_options["snowfakery_version"] = parse_result.version
 
-    plugin_options = process_plugins_options(snowfakery_plugins, plugin_options or {})
+    plugin_options = process_plugins_options(snowfakery_plugins, plugin_options)
 
     # figure out how it relates to CLI-supplied generation variables
     options, extra_options = merge_options(
@@ -203,7 +209,6 @@ def process_plugins_options(
     e.g. the option name that the user specifies on the CLI or API is just "org_name"
          but we use the long name internally to avoid clashing with the
          user's variable names."""
-
     allowed_options = collect_allowed_plugin_options(tuple(plugins.values()))
     plugin_options = {}
     for option in allowed_options:

--- a/snowfakery/standard_plugins/SnowfakeryVersion.py
+++ b/snowfakery/standard_plugins/SnowfakeryVersion.py
@@ -1,0 +1,12 @@
+from snowfakery import SnowfakeryPlugin
+from snowfakery.plugins import PluginOption
+
+plugin_options_version = (
+    "snowfakery.standard_plugins.SnowfakeryVersion.snowfakery_version"
+)
+
+
+class SnowfakeryVersion(SnowfakeryPlugin):
+    allowed_options = [
+        PluginOption(plugin_options_version, int),
+    ]

--- a/tests/errors/bad_version.recipe.yml
+++ b/tests/errors/bad_version.recipe.yml
@@ -1,0 +1,2 @@
+- snowfakery_version: 4
+- object: Example

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,40 @@
+import pytest
+from io import StringIO
+from snowfakery import generate_data
+from snowfakery import data_gen_exceptions as exc
+
+
+class TestDates:
+    def test_old_dates_as_strings(self, generated_rows):
+        yaml = """
+        - object: OBJ
+          fields:
+            basedate: ${{datetime(year=2000, month=1, day=1)}}
+            dateplus: ${{basedate + "XYZZY"}}
+        """
+        generate_data(StringIO(yaml))
+        date = generated_rows.table_values("OBJ", 1, "dateplus")
+        assert date.startswith("2000")
+        assert date.endswith("XYZZY")
+
+    def test_date_math__native_types(self, generated_rows):
+        yaml = """
+        - object: OBJ
+          fields:
+            basedate: ${{datetime(year=2000, month=1, day=1)}}
+            dateplus: ${{basedate + relativedelta(years=22)}}
+        """
+        generate_data(StringIO(yaml), plugin_options={"snowfakery_version": 3})
+        date = generated_rows.table_values("OBJ", 1, "dateplus")
+        assert date == "2022-01-01T00:00:00+00:00"
+
+    def test_date_math__native_types__error(self, generated_rows):
+        yaml = """
+        - object: OBJ
+          fields:
+            basedate: ${{datetime(year=2000, month=1, day=1)}}
+            dateplus: ${{basedate + "XYZZY"}}
+        """
+        with pytest.raises(exc.DataGenValueError) as e:
+            generate_data(StringIO(yaml), plugin_options={"snowfakery_version": 3})
+        assert "dateplus" in str(e.value)

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -123,15 +123,17 @@ class TestFaker:
         assert (date.today() - the_date).days > 80
         assert (date.today() - the_date).days < 130
 
-    def test_date_times(self, generated_rows):
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
+    def test_date_times(self, generated_rows, snowfakery_version):
         with open("tests/test_datetimes.yml") as yaml:
-            generate(yaml)
+            generate(yaml, plugin_options={"snowfakery_version": snowfakery_version})
 
         for dt in generated_rows.table_values("Contact", field="EmailBouncedDate"):
             assert "+0" in dt or dt.endswith("Z"), dt
             assert dateparser.isoparse(dt).tzinfo
 
-    def test_hidden_fakers(self):
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
+    def test_hidden_fakers(self, snowfakery_version):
         yaml = """
         - object: A
           fields:
@@ -139,11 +141,15 @@ class TestFaker:
               fake: DateTimeThisCentury
         """
         with pytest.raises(exc.DataGenError) as e:
-            generate(StringIO(yaml))
+            generate(
+                StringIO(yaml),
+                plugin_options={"snowfakery_version": snowfakery_version},
+            )
 
         assert e
 
-    def test_bad_tz_param(self):
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
+    def test_bad_tz_param(self, snowfakery_version):
         yaml = """
         - object: A
           fields:
@@ -152,12 +158,16 @@ class TestFaker:
                 timezone: PST
         """
         with pytest.raises(exc.DataGenError) as e:
-            generate(StringIO(yaml))
+            generate(
+                StringIO(yaml),
+                plugin_options={"snowfakery_version": snowfakery_version},
+            )
 
         assert "timezone" in str(e.value)
         assert "relativedelta" in str(e.value)
 
-    def test_no_timezone(self, generated_rows):
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
+    def test_no_timezone(self, generated_rows, snowfakery_version):
         yaml = """
         - object: A
           fields:
@@ -165,13 +175,20 @@ class TestFaker:
               fake.datetime:
                 timezone: False
         """
-        generate(StringIO(yaml))
+        generate(
+            StringIO(yaml),
+            plugin_options={"snowfakery_version": snowfakery_version},
+        )
         date = generated_rows.table_values("A", 0, "date")
         assert dateparser.isoparse(date).tzinfo is None
 
-    def test_relative_dates(self, generated_rows):
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
+    def test_relative_dates(self, generated_rows, snowfakery_version):
         with open("tests/test_relative_dates.yml") as f:
-            generate(f)
+            generate(
+                f,
+                plugin_options={"snowfakery_version": snowfakery_version},
+            )
         now = datetime.now(timezone.utc)
         # there is a miniscule chance that FutureDateTime picks a DateTime 1 second in the future
         # and then by the time we get here it isn't the future anymore. We'll see if it ever

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,49 @@
+from io import StringIO
+
+import pytest
+
+from snowfakery import data_gen_exceptions as exc
+from snowfakery import generate_data
+
+
+class TestVersion:
+    def test_version_3_date_handling(self, generated_rows):
+        yaml = """
+            - snowfakery_version: 3
+            - object: Example
+              fields:
+                y: ${{datetime(year=2000, month=1, day=1)}}
+                z: ${{y.date()}}"""
+        generate_data(StringIO(yaml))
+        assert generated_rows.table_values("Example", 0, "z")
+
+    def test_version_2_date_handling(self, generated_rows):
+        yaml = """
+            - snowfakery_version: 2
+            - object: Example
+              fields:
+                y: ${{datetime(year=2000, month=1, day=1)}}
+                z: ${{y + "XYZZY"}}"""
+        generate_data(StringIO(yaml))
+        assert generated_rows.table_values("Example", 0, "z").endswith("XYZZY")
+
+    def test_conflicting_versions(self, generated_rows):
+        yaml = """
+            - snowfakery_version: 2
+            - snowfakery_version: 3
+            - object: Example
+              fields:
+                y: ${{datetime(year=2000, month=1, day=1)}}
+                z: ${{y + "XYZZY"}}"""
+        with pytest.raises(exc.DataGenSyntaxError) as e:
+            generate_data(StringIO(yaml))
+        assert "conflicting versions" in str(e.value)
+
+    def test_conflicting_unknown_version(self, generated_rows):
+        yaml = """
+            - snowfakery_version: 4
+            - object: Example
+        """
+        with pytest.raises(exc.DataGenSyntaxError) as e:
+            generate_data(StringIO(yaml))
+        assert "Version" in str(e.value)


### PR DESCRIPTION
The way Jinja-in-Snowfakery was configured before, all objects were serialized to strings before being captured as fields. This change defers the serialization to the output_stream which allows operations like:

foo: ${{OtherObj.IntField + 5}}

or

foo: ${{OtherObj.DateField + relativedelta(days=3)}}

etc.

Allowing formulas to manipulate values that do not start or end as strings will have a variety of benefits.

It is theoretically possible that this will break a recipe, but it will break a very tiny number. As an example, this would have previously generated a string, and will now generate an error:

foo: ${{"".class}}

