### PR TITLE
Document that now() does not generate unique results

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -784,7 +784,7 @@ Macros can include other macros. In fact, macros are especially powerful if you 
 
 ### Debug
 
-You can use Snowfakery's `debug` function to output values to `stderr` (usually, the command line) for debugging. 
+You can use Snowfakery's `debug` function to output values to `stderr` (usually, the command line) for debugging.
 
 The debug function can "wrap" any formula expression and return its value.
 
@@ -1034,10 +1034,8 @@ This would generate field values similar to these:
 current_datetime=2022-02-23 15:39:49.513086+00:00, current_datetime_as_number=1645630789.513975, current_datetime_without_microseconds=1645630789
 ```
 
-Experimentally, this variable seems to return a unique value
-every time it is called, but it might depend on
-your operating system and hardware setup
-(e.g. a very fast CPU with a very slow system clock).
+Experimentally, this variable is not guaranteed to return a unique
+value each time, especially on Windows.
 
 #### `fake:` and `fake.`
 

--- a/tests/test_template_funcs.py
+++ b/tests/test_template_funcs.py
@@ -254,9 +254,6 @@ class TestTemplateFuncs:
         generate(StringIO(yaml), {}, None)
         assert datetime.fromisoformat(generated_rows.table_values("A", 0, "a"))
         assert datetime.fromisoformat(generated_rows.table_values("A", 0, "b"))
-        assert generated_rows.table_values("A", 0, "a") != generated_rows.table_values(
-            "A", 0, "b"
-        )
 
     @mock.patch("snowfakery.data_generator_runtime.datetime")
     def test_now_calls_datetime_now(self, datetime):


### PR DESCRIPTION
I had a test that was checking whether subsequent calls to now() were guaranteed to generate different values for use as uniquifying timestamps. The answer seems to be "no" on Windows, so I've removed the test and documented the situation.