### PR TITLE
Allow decimal datatype

### DIFF
--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -344,8 +344,10 @@ class Interpreter:
             "snowfakery.standard_plugins.SnowfakeryVersion.snowfakery_version", 2
         )
         assert snowfakery_version in (2, 3)
-        native_types = snowfakery_version == 3
-        self.template_evaluator_factory = JinjaTemplateEvaluatorFactory(native_types)
+        self.native_types = snowfakery_version == 3
+        self.template_evaluator_factory = JinjaTemplateEvaluatorFactory(
+            self.native_types
+        )
 
     def execute(self):
         self.current_context = RuntimeContext(interpreter=self)

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -333,6 +333,8 @@ class SimpleValue(FieldDefinition):
         if evaluator:
             try:
                 val = evaluator(context)
+                if hasattr(val, "render"):
+                    val = val.render()
             except jinja2.exceptions.UndefinedError as e:
                 raise DataGenNameError(e.message, self.filename, self.line_num) from e
             except Exception as e:
@@ -340,7 +342,9 @@ class SimpleValue(FieldDefinition):
         else:
             val = self.definition
         context.unique_context_identifier = old_context_identifier
-        return look_for_number(val) if isinstance(val, str) else val
+        if isinstance(val, str) and not context.interpreter.native_types:
+            val = look_for_number(val)
+        return val
 
     def __repr__(self):
         return f"<{self.__class__.__name__ , self.definition}>"

--- a/snowfakery/output_streams.py
+++ b/snowfakery/output_streams.py
@@ -5,6 +5,7 @@ import csv
 import subprocess
 import datetime
 import sys
+from decimal import Decimal
 from pathlib import Path
 from collections import namedtuple, defaultdict
 from typing import Dict, Union, Optional, Mapping, Callable, Sequence
@@ -54,6 +55,7 @@ class OutputStream(ABC):
         datetime.datetime: format_datetime,
         type(None): noop,
         bool: int,
+        Decimal: str,
     }
     uses_folder = False
     uses_path = False

--- a/snowfakery/utils/template_utils.py
+++ b/snowfakery/utils/template_utils.py
@@ -37,6 +37,9 @@ class StringGenerator:
     def __radd__(self, other):
         return str(other) + str(self)
 
+    def render(self):
+        return self.func()
+
 
 class FakerTemplateLibrary:
     """A Jinja template library to add the fake.xyz objects to templates"""

--- a/tests/decimal.yml
+++ b/tests/decimal.yml
@@ -1,0 +1,17 @@
+- snowfakery_version: 3
+- object: Foo
+  fields:
+    lat: ${{fake.latitude | string}} # jinja2 will still make a number
+    long: ${{fake.longitude | string}} # https://github.com/pallets/jinja/issues/1200
+
+- object: Bar
+  fields:
+    lat2: ${{fake.latitude}}
+    long2: ${{fake.longitude}}
+
+- object: Baz
+  fields:
+    lat3:
+      fake: latitude
+    long3:
+      fake: longitude

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -50,14 +50,19 @@ class TestFaker:
         generate(StringIO(yaml), {})
         assert len(row_values(write_row_mock, 0, "country")) == 2
 
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
     @mock.patch(write_row_path)
-    def test_fake_inline(self, write_row_mock):
+    def test_fake_inline(self, write_row_mock, snowfakery_version):
         yaml = """
         - object: OBJ
           fields:
             country: ${{fake.country_code(representation='alpha-2')}}
         """
-        generate(StringIO(yaml), {}, None)
+        generate(
+            StringIO(yaml),
+            {},
+            plugin_options={"snowfakery_version": snowfakery_version},
+        )
         assert len(row_values(write_row_mock, 0, "country")) == 2
 
     @mock.patch(write_row_path)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest import mock
 from io import StringIO
 
@@ -36,3 +37,13 @@ class TestTypes:
         generate(StringIO(yaml))
         assert generated_rows.row_values(0, "foo") == 0.1
         assert generated_rows.row_values(0, "foo2") == 0.1
+
+    @pytest.mark.parametrize("snowfakery_version", (2, 3))
+    def test_decimal(self, generated_rows, snowfakery_version):
+        with open("tests/decimal.yml") as f:
+            generate(f, plugin_options={"snowfakery_version": snowfakery_version})
+        assert isinstance(
+            generated_rows.table_values("Foo", 0)["lat"], float
+        )  # Jinja quirk
+        assert isinstance(generated_rows.table_values("Bar", 0)["lat2"], str)
+        assert isinstance(generated_rows.table_values("Baz", 0)["lat3"], str)


### PR DESCRIPTION
Decimal fakers were causing a problem because there was no serialization rule for them.﻿

In the process of fixing it I discovered another small bug relating to this syntax:

fieldname: ${{fake.foo}}

This was causing an exception in the new Native Types mode of Snowfakery. Now it's fixed.