### PR TITLE
Make Snowfakery compatible with latest CCI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from io import StringIO
 import pytest
 import yaml
 from sqlalchemy import create_engine
+from vcr.serializers import yamlserializer
 
 try:
     import cumulusci
@@ -121,3 +122,8 @@ def generate_data_with_continuation():
 @pytest.fixture(scope="session")
 def snowfakery_rootdir():
     return Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="session")
+def salesforce_serializer():
+    return yamlserializer


### PR DESCRIPTION
Snowfakery's integration testing infrastructure is based on CumulusCI's. CumulusCI's now depends on client apps declaring the `salesforce_serializer`. This PR declares a `salesforce_serializer` which is just the default VCR serializer. Snowfakery doesn't need the compressed serializer yet.