### PR TITLE
Upsert when Snowfakery is used within CumulusCI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2090,6 +2090,8 @@ An update recipe should have a single top-level object with no `count` on it.
 The recipe can take `options` if needed. It will generate the same number of
 output rows as input rows.
 
+To do updates in a Salesforce org, refer to the [CumulusCI documentation](https://cumulusci.readthedocs.io/en/stable/data.html#update-data).
+
 ## Use Snowfakery with Salesforce
 
 Snowfakery recipes that generate Salesforce records are like any other Snowfakery recipes, but instead use `SObject` names for the `objects`. There are several examples [in the Snowfakery repository](https://github.com/SFDO-Tooling/Snowfakery/tree/main/examples/salesforce).

--- a/docs/salesforce.md
+++ b/docs/salesforce.md
@@ -368,3 +368,7 @@ Files can be used as Salesforce ContentVersions like this:
     FirstPublishLocationId:
       reference: Account
 ```
+
+## Other features
+
+To do updates or upserts in a Salesforce org, refer to the [CumulusCI documentation](https://cumulusci.readthedocs.io/en/stable/data.html#update-data).

--- a/schema/snowfakery_recipe.jsonschema.json
+++ b/schema/snowfakery_recipe.jsonschema.json
@@ -45,6 +45,9 @@
         "just_once": {
           "type": "boolean"
         },
+        "update_key": {
+          "type": "string"
+        },
         "count": {
           "anyOf": [
             {
@@ -79,9 +82,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "object"
-      ]
+      "required": ["object"]
     },
     "include_file": {
       "title": "Include File",
@@ -93,9 +94,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "include_file"
-      ]
+      "required": ["include_file"]
     },
     "plugin": {
       "title": "Plugin Declaration",
@@ -107,9 +106,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "plugin"
-      ]
+      "required": ["plugin"]
     },
     "var": {
       "title": "Variable",
@@ -151,10 +148,7 @@
           ]
         }
       },
-      "required": [
-        "var",
-        "value"
-      ]
+      "required": ["var", "value"]
     },
     "option": {
       "title": "Variable",
@@ -196,9 +190,7 @@
           ]
         }
       },
-      "required": [
-        "option"
-      ]
+      "required": ["option"]
     },
     "macro": {
       "title": "Macro",

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -247,6 +247,10 @@ class ObjectTemplate:
         """Generate an individual row"""
         id = context.generate_id(self.nickname)
         row = {"id": id}
+
+        # add a column keeping track of what update_key was specified by
+        # the template. This allows multiple templates to have different
+        # update_keys.
         if self.update_key:
             row["_sf_update_key"] = self.update_key
         sobj = ObjectRow(self.tablename, row, index)

--- a/snowfakery/data_generator_runtime_object_model.py
+++ b/snowfakery/data_generator_runtime_object_model.py
@@ -136,6 +136,7 @@ class ObjectTemplate:
         just_once: bool = False,
         fields: Sequence = (),
         friends: Sequence = (),
+        update_key: str = None,
     ):
         self.tablename = tablename
         self.nickname = nickname
@@ -146,6 +147,7 @@ class ObjectTemplate:
         self.fields = fields
         self.friends = friends
         self.for_each_expr = for_each_expr
+        self.update_key = update_key
 
         if count_expr and for_each_expr:
             raise DataGenSyntaxError(
@@ -245,6 +247,8 @@ class ObjectTemplate:
         """Generate an individual row"""
         id = context.generate_id(self.nickname)
         row = {"id": id}
+        if self.update_key:
+            row["_sf_update_key"] = self.update_key
         sobj = ObjectRow(self.tablename, row, index)
 
         context.register_object(sobj, self.nickname, self.just_once)

--- a/snowfakery/parse_recipe_yaml.py
+++ b/snowfakery/parse_recipe_yaml.py
@@ -62,6 +62,7 @@ class TableInfo:
         self.name = name
         self.fields = {}
         self.friends = {}
+        self.has_update_keys = False
         self._templates = []
 
     def register(self, template: ObjectTemplate) -> None:
@@ -79,6 +80,8 @@ class TableInfo:
                 if hasattr(friend, "tablename")
             }
         )
+        if template.update_key:
+            self.has_update_keys = True
         self._templates.append(template)
 
     def __repr__(self) -> str:

--- a/snowfakery/parse_recipe_yaml.py
+++ b/snowfakery/parse_recipe_yaml.py
@@ -362,6 +362,7 @@ def parse_object_template(yaml_sobj: Dict, context: ParseContext) -> ObjectTempl
             "just_once": bool,
             "for_each": dict,
             "count": (str, int, dict),
+            "update_key": str,
         },
         context=context,
     )
@@ -385,6 +386,7 @@ def parse_object_template(yaml_sobj: Dict, context: ParseContext) -> ObjectTempl
         sobj_def["nickname"] = nickname = parsed_template.nickname
         check_identifier(nickname, yaml_sobj, "Nicknames")
         sobj_def["just_once"] = parsed_template.just_once or False
+        sobj_def["update_key"] = parsed_template.update_key or None
         sobj_def["line_num"] = parsed_template.line_num.line_num
         sobj_def["filename"] = parsed_template.line_num.filename
 

--- a/tests/upsert.yml
+++ b/tests/upsert.yml
@@ -1,0 +1,6 @@
+- object: Contact
+  update_key: email
+  fields:
+    firstname: Buster
+    lastname: Bluth
+    email: buster@bluth.com


### PR DESCRIPTION
Adds a top-level key called `update_key` which allows a Snowfakery template to do upserts instead of inserts. If the key matches an existing object, the object is updated instead of upserted.