### PR TITLE
Keep track of nicknames for counters

### DIFF
--- a/snowfakery/row_history.py
+++ b/snowfakery/row_history.py
@@ -49,6 +49,7 @@ class RowHistory:
 
         if nickname:
             nickname_id = self._get_nickname_id(tablename, nickname)
+            self.table_counters[nickname] = nickname_id
         else:
             nickname_id = None
 
@@ -93,13 +94,17 @@ class RowHistory:
                 warnings.warn("Global scope is an experimental feature.")
                 self.already_warned = True
             min_id = 1
+        elif nickname:
+            # nickname counters are reset every loop, so 1 is the right choice
+            # OR they are just_once in which case 
+            min_id = self.local_counters.get(nickname, 0) + 1
         else:
             min_id = self.local_counters.get(tablename, 0) + 1
         # if no records can be found in this iteration
         # just look through the whole table.
         #
         # This happens usually when you are referring to just_once
-        if max_id <= min_id:
+        if max_id < min_id:
             min_id = 1
 
         if nickname:

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -737,6 +737,28 @@ class TestRandomReferencesNew:
         assert generated_rows.table_values("B", 1, "A_ref") == "A(2)"
         assert generated_rows.table_values("B", 2, "A_ref") == "A(1)"
 
+    def test_random_reference_to_nickname__subsequent_iterations(self, generated_rows):
+        yaml = """
+      - object: A
+        just_once: True
+      - object: A
+      - object: A
+        nickname: nicky
+        fields:
+          name: nicky
+      - object: B
+        count: 2
+        fields:
+            A_ref:
+              random_reference: nicky
+            nameref: ${{A_ref.name}}
+    """
+        with mock.patch("snowfakery.row_history.randint") as randint:
+            randint.side_effect = lambda x,y: x
+            generate(StringIO(yaml), stopping_criteria=StoppingCriteria("B", 10))
+        assert generated_rows.table_values("B", 10, "A_ref") == "A(11)"
+        assert generated_rows.table_values("B", 10, "nameref") == "nicky"
+
     def test_random_reference__properties(self, generated_rows):
         yaml = """
               - object: GrandParent


### PR DESCRIPTION
This case failed previously:

```
      - object: A
        just_once: True
      - object: A
      - object: A
        nickname: nicky
        fields:
          name: nicky
      - object: B
        count: 2
        fields:
            A_ref:
              random_reference: nicky
            nameref: ${{A_ref.name}}
```

It would not find "nicky" properly. It would find one of the other "A" objects.