### PR TITLE
Refactor YAML Loading

### DIFF
--- a/snowfakery/data_generator.py
+++ b/snowfakery/data_generator.py
@@ -95,7 +95,7 @@ def load_continuation_yaml(continuation_file: OpenFileLike):
 def save_continuation_yaml(continuation_data: Globals, continuation_file: OpenFileLike):
     """Save the global interpreter state from Globals into a continuation_file"""
     yaml.dump(
-        continuation_data.__getstate__(),
+        continuation_data,
         continuation_file,
         Dumper=SnowfakeryDumper,
     )

--- a/snowfakery/object_rows.py
+++ b/snowfakery/object_rows.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 
 import yaml
 import snowfakery  # noqa
-from .utils.yaml_utils import SnowfakeryDumper
+from .utils.yaml_utils import register_for_continuation
 from contextvars import ContextVar
 
 IdManager = "snowfakery.data_generator_runtime.IdManager"
@@ -13,10 +13,6 @@ class ObjectRow:
     """Represents a single row
 
     Uses __getattr__ so that the template evaluator can use dot-notation."""
-
-    yaml_loader = yaml.SafeLoader
-    yaml_dumper = SnowfakeryDumper
-    yaml_tag = "!snowfakery_objectrow"
 
     # be careful changing these slots because these objects must be serializable
     # to YAML and JSON
@@ -49,17 +45,26 @@ class ObjectRow:
         except Exception:
             return super().__repr__()
 
-    def __getstate__(self):
+    def get_continuation_state(self):
         """Get the state of this ObjectRow for serialization.
 
         Do not include related ObjectRows because circular
         references in serialization formats cause problems."""
+
+        # If we decided to try to serialize hierarchies, we could
+        # do it like this:
+        #   * keep track of if an object has already been serialized using a
+        #     property of the SnowfakeryDumper
+        #   * If so, output an ObjectReference instead of an ObjectRow
         values = {k: v for k, v in self._values.items() if not isinstance(v, ObjectRow)}
         return {"_tablename": self._tablename, "_values": values}
 
     def __setstate__(self, state):
         for slot, value in state.items():
             setattr(self, slot, value)
+
+
+register_for_continuation(ObjectRow, ObjectRow.get_continuation_state)
 
 
 class ObjectReference(yaml.YAMLObject):

--- a/snowfakery/plugins.py
+++ b/snowfakery/plugins.py
@@ -8,13 +8,11 @@ from unittest.mock import patch
 from functools import wraps
 import typing as T
 
-import yaml
-from yaml.representer import Representer
 from faker.providers import BaseProvider as FakerProvider
 from dateutil.relativedelta import relativedelta
 
 import snowfakery.data_gen_exceptions as exc
-from .utils.yaml_utils import SnowfakeryDumper
+from snowfakery.utils.yaml_utils import register_for_continuation
 from .utils.collections import CaseInsensitiveDict
 
 from numbers import Number
@@ -306,17 +304,7 @@ class PluginResult:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        _register_for_continuation(cls)
-
-
-def _register_for_continuation(cls):
-    SnowfakeryDumper.add_representer(cls, Representer.represent_object)
-    yaml.SafeLoader.add_constructor(
-        f"tag:yaml.org,2002:python/object/apply:{cls.__module__}.{cls.__name__}",
-        lambda loader, node: cls._from_continuation(
-            loader.construct_mapping(node.value[0])
-        ),
-    )
+        register_for_continuation(cls)
 
 
 class PluginResultIterator(PluginResult):
@@ -372,4 +360,4 @@ class PluginOption:
 
 
 # round-trip PluginResult objects through continuation YAML if needed.
-_register_for_continuation(PluginResult)
+register_for_continuation(PluginResult)

--- a/snowfakery/row_history.py
+++ b/snowfakery/row_history.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from random import randint
 
 from snowfakery import data_gen_exceptions as exc
-from snowfakery.object_rows import LazyLoadedObjectReference
+from snowfakery.object_rows import LazyLoadedObjectReference, ObjectRow
 from snowfakery.utils.pickle import RestrictedPickler
 from snowfakery.object_rows import NicknameSlot, ObjectReference
 
@@ -167,7 +167,11 @@ _DISPATCH_TABLE = {
     NicknameSlot: lambda n: (
         ObjectReference,
         (n._tablename, n.allocated_id),
-    )
+    ),
+    ObjectRow: lambda v: (
+        ObjectRow,
+        (v._tablename, v._values),
+    ),
 }
 
 _SAFE_CLASSES = {

--- a/snowfakery/row_history.py
+++ b/snowfakery/row_history.py
@@ -7,7 +7,8 @@ from random import randint
 
 from snowfakery import data_gen_exceptions as exc
 from snowfakery.object_rows import LazyLoadedObjectReference
-from snowfakery.utils.pickle import restricted_dumps, restricted_loads
+from snowfakery.utils.pickle import RestrictedPickler
+from snowfakery.object_rows import NicknameSlot, ObjectReference
 
 
 class RowHistory:
@@ -35,6 +36,7 @@ class RowHistory:
         }
         for table in tables_to_keep_history_for:
             _make_history_table(self.conn, table)
+        self.pickler = RestrictedPickler(_DISPATCH_TABLE, _SAFE_CLASSES)
 
     def reset_locals(self):
         """Reset the minimum count that counts as "local" """
@@ -58,7 +60,7 @@ class RowHistory:
         # "join" across multiple tables would have other costs (even if done lazily).
         # For now this seems best and simplest.
         # The data de-dupling algorithm would be slightly complex and slow.
-        data = restricted_dumps(row)
+        data = self.pickler.dumps(row)
         self.conn.execute(
             f'INSERT INTO "{tablename}" VALUES (?, ?, ?, ?)',
             (row_id, nickname, nickname_id, data),
@@ -95,8 +97,6 @@ class RowHistory:
                 self.already_warned = True
             min_id = 1
         elif nickname:
-            # nickname counters are reset every loop, so 1 is the right choice
-            # OR they are just_once in which case 
             min_id = self.local_counters.get(nickname, 0) + 1
         else:
             min_id = self.local_counters.get(tablename, 0) + 1
@@ -126,7 +126,7 @@ class RowHistory:
         first_row = next(qr, None)
         assert first_row, f"Something went wrong: we cannot find {tablename}: {row_id}"
 
-        return restricted_loads(first_row[0])
+        return self.pickler.loads(first_row[0])
 
     def find_row_id_for_nickname_id(
         self, tablename: str, nickname: str, nickname_id: int
@@ -161,3 +161,22 @@ def _make_history_table(conn, tablename):
     c.execute(
         f'CREATE UNIQUE INDEX "{tablename}_nickname_id" ON "{tablename}" (nickname, nickname_id);'
     )
+
+
+_DISPATCH_TABLE = {
+    NicknameSlot: lambda n: (
+        ObjectReference,
+        (n._tablename, n.allocated_id),
+    )
+}
+
+_SAFE_CLASSES = {
+    ("snowfakery.object_rows", "ObjectRow"),
+    ("snowfakery.object_rows", "ObjectReference"),
+    ("snowfakery.object_rows", "LazyLoadedObjectReference"),
+    ("decimal", "Decimal"),
+    ("datetime", "date"),
+    ("datetime", "datetime"),
+    ("datetime", "timedelta"),
+    ("datetime", "timezone"),
+}

--- a/snowfakery/utils/pickle.py
+++ b/snowfakery/utils/pickle.py
@@ -7,22 +7,31 @@ import typing as T
 
 import warnings
 
-from snowfakery.object_rows import NicknameSlot, ObjectReference
 
-_DISPATCH_TABLE = copyreg.dispatch_table.copy()
-_DISPATCH_TABLE[NicknameSlot] = lambda n: (
-    ObjectReference,
-    (n._tablename, n.allocated_id),
-)
+DispatchDefinition = T.Callable[[T.Any], T.Tuple[type, T.Tuple]]
 
 
-def restricted_dumps(data):
-    """Only allow saving "safe" classes"""
-    outs = io.BytesIO()
-    pickler = pickle.Pickler(outs)
-    pickler.dispatch_table = _DISPATCH_TABLE
-    pickler.dump(data)
-    return outs.getvalue()
+class RestrictedPickler:
+    def __init__(
+        self,
+        dispatchers: T.Mapping[type, DispatchDefinition],
+        _SAFE_CLASSES: T.Set[T.Tuple[str, str]],
+    ) -> None:
+        self._DISPATCH_TABLE = copyreg.dispatch_table.copy()
+        self._DISPATCH_TABLE.update(dispatchers)
+        self.RestrictedUnpickler = _get_RestrictedUnpicklerClass(_SAFE_CLASSES)
+
+    def dumps(self, data):
+        """Only allow saving "safe" classes"""
+        outs = io.BytesIO()
+        pickler = pickle.Pickler(outs)
+        pickler.dispatch_table = self._DISPATCH_TABLE
+        pickler.dump(data)
+        return outs.getvalue()
+
+    def loads(self, s):
+        """Helper function analogous to pickle.loads()."""
+        return self.RestrictedUnpickler(io.BytesIO(s)).load()
 
 
 class Type_Cannot_Be_Used_With_Random_Reference(T.NamedTuple):
@@ -32,35 +41,24 @@ class Type_Cannot_Be_Used_With_Random_Reference(T.NamedTuple):
     name: str
 
 
-_SAFE_CLASSES = {
-    ("snowfakery.object_rows", "ObjectRow"),
-    ("snowfakery.object_rows", "ObjectReference"),
-    ("snowfakery.object_rows", "LazyLoadedObjectReference"),
-    ("decimal", "Decimal"),
-    ("datetime", "date"),
-    ("datetime", "datetime"),
-    ("datetime", "timedelta"),
-    ("datetime", "timezone"),
-}
+def _get_RestrictedUnpicklerClass(_SAFE_CLASSES):
+    class RestrictedUnpickler(pickle.Unpickler):
+        """Safe unpickler with an allowed-list"""
 
+        count = 0
 
-class RestrictedUnpickler(pickle.Unpickler):
-    """Safe unpickler with an allowed-list"""
+        def find_class(self, module, name):
+            # Only allow safe classes from builtins.
+            if (module, name) in _SAFE_CLASSES:
+                return super().find_class(module, name)
+            else:
+                # warn first 10 times
+                if RestrictedUnpickler.count < 10:
+                    warnings.warn(f"Cannot save and refer to {module}, {name}")
+                    RestrictedUnpickler.count += 1
+                # Return a "safe" object that does nothing.
+                return lambda *args: Type_Cannot_Be_Used_With_Random_Reference(
+                    module, name
+                )
 
-    count = 0
-
-    def find_class(self, module, name):
-        # Only allow safe classes from builtins.
-        if (module, name) in _SAFE_CLASSES:
-            return super().find_class(module, name)
-        else:
-            # Return a "safe" object that does nothing.
-            if RestrictedUnpickler.count < 10:
-                warnings.warn(f"Cannot save and refer to {module}, {name}")
-                RestrictedUnpickler.count += 1
-            return lambda *args: Type_Cannot_Be_Used_With_Random_Reference(module, name)
-
-
-def restricted_loads(s):
-    """Helper function analogous to pickle.loads()."""
-    return RestrictedUnpickler(io.BytesIO(s)).load()
+    return RestrictedUnpickler

--- a/snowfakery/utils/yaml_utils.py
+++ b/snowfakery/utils/yaml_utils.py
@@ -1,4 +1,6 @@
-from yaml import SafeDumper
+from typing import Callable
+from yaml import SafeDumper, SafeLoader
+from yaml.representer import Representer
 
 
 class SnowfakeryDumper(SafeDumper):
@@ -9,3 +11,28 @@ def hydrate(cls, data):
     obj = cls.__new__(cls)
     obj.__setstate__(data)
     return obj
+
+
+# Evaluate whether its cleaner for functions to bypass  register_for_continuation
+# and go directly to SnowfakeryDumper.add_representer.
+#
+#
+
+
+def represent_continuation(dumper: SnowfakeryDumper, data):
+    if isinstance(data, dict):
+        return Representer.represent_dict(dumper, data)
+    else:
+        return Representer.represent_object(dumper, data)
+
+
+def register_for_continuation(cls, dump_transformer: Callable = lambda x: x):
+    SnowfakeryDumper.add_representer(
+        cls, lambda self, data: represent_continuation(self, dump_transformer(data))
+    )
+    SafeLoader.add_constructor(
+        f"tag:yaml.org,2002:python/object/apply:{cls.__module__}.{cls.__name__}",
+        lambda loader, node: cls._from_continuation(
+            loader.construct_mapping(node.value[0])
+        ),
+    )

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -913,32 +913,56 @@ class TestRandomReferencesNew:
         assert parse_date(generated_rows.table_values("B", 1, "datetime1ref"))
         assert parse_date(generated_rows.table_values("B", 1, "datetime2ref"))
 
-    # TODO: Make this work
-    # def test_random_references__nested_1(self, generate_data_with_continuation, generated_rows):
-    #     yaml = """
-    #   - object: Parent
-    #     count: 2
-    #     fields:
-    #       child1:
-    #         - object: Child1
-    #           fields:
-    #             child2:
-    #               - object: Child2
-    #                 fields:
-    #                   name: TheName
-    #   - object: Child3
-    #     fields:
-    #         A_ref:
-    #           random_reference:
-    #             to: Parent
-    #         nested_name:
-    #           ${{A_ref.child1.child2.name}}
-    # """
-    #     generate(StringIO(yaml))
-    #     # generate_data_with_continuation(
-    #     #     yaml=yaml,
-    #     #     target_number=("Parent", 4),
-    #     #     times=1,
-    #     # )
-    #     assert generated_rows.table_values("Child3", 1, "nested_name") == "TheName"
-    #     assert generated_rows.table_values("Child3", -1, "nested_name") == "TheName"
+    def test_random_references__nested(self, generated_rows):
+        yaml = """
+      - object: Parent
+        count: 2
+        fields:
+          child1:
+            - object: Child1
+              fields:
+                child2:
+                  - object: Child2
+                    fields:
+                      name: TheName
+      - object: Child3
+        fields:
+            A_ref:
+              random_reference:
+                to: Parent
+            nested_name:
+              ${{A_ref.child1.child2.name}}
+    """
+        generate(StringIO(yaml))
+        assert generated_rows.table_values("Child3", 1, "nested_name") == "TheName"
+        assert generated_rows.table_values("Child3", -1, "nested_name") == "TheName"
+
+    def test_random_references__nested__with_continuation(
+        self, generate_data_with_continuation, generated_rows
+    ):
+        yaml = """
+      - object: Parent
+        count: 2
+        fields:
+          child1:
+            - object: Child1
+              fields:
+                child2:
+                  - object: Child2
+                    fields:
+                      name: TheName
+      - object: Child3
+        fields:
+            A_ref:
+              random_reference:
+                to: Parent
+            nested_name:
+              ${{A_ref.child1.child2.name}}
+    """
+        generate_data_with_continuation(
+            yaml=yaml,
+            target_number=("Parent", 4),
+            times=1,
+        )
+        assert generated_rows.table_values("Child3", 1, "nested_name") == "TheName"
+        assert generated_rows.table_values("Child3", -1, "nested_name") == "TheName"

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -416,7 +416,6 @@ class TestReferences:
 
 
 class TestRandomReferencesOriginal:
-    ## For reviewer: These tests were all moved and are not new
     def test_random_reference_simple(self, generated_rows):
         yaml = """                  #1
       - object: A                   #2
@@ -754,7 +753,7 @@ class TestRandomReferencesNew:
             nameref: ${{A_ref.name}}
     """
         with mock.patch("snowfakery.row_history.randint") as randint:
-            randint.side_effect = lambda x,y: x
+            randint.side_effect = lambda x, y: x
             generate(StringIO(yaml), stopping_criteria=StoppingCriteria("B", 10))
         assert generated_rows.table_values("B", 10, "A_ref") == "A(11)"
         assert generated_rows.table_values("B", 10, "nameref") == "nicky"
@@ -913,3 +912,33 @@ class TestRandomReferencesNew:
         assert float(generated_rows.table_values("B", 1, "decimalref"))
         assert parse_date(generated_rows.table_values("B", 1, "datetime1ref"))
         assert parse_date(generated_rows.table_values("B", 1, "datetime2ref"))
+
+    # TODO: Make this work
+    # def test_random_references__nested_1(self, generate_data_with_continuation, generated_rows):
+    #     yaml = """
+    #   - object: Parent
+    #     count: 2
+    #     fields:
+    #       child1:
+    #         - object: Child1
+    #           fields:
+    #             child2:
+    #               - object: Child2
+    #                 fields:
+    #                   name: TheName
+    #   - object: Child3
+    #     fields:
+    #         A_ref:
+    #           random_reference:
+    #             to: Parent
+    #         nested_name:
+    #           ${{A_ref.child1.child2.name}}
+    # """
+    #     generate(StringIO(yaml))
+    #     # generate_data_with_continuation(
+    #     #     yaml=yaml,
+    #     #     target_number=("Parent", 4),
+    #     #     times=1,
+    #     # )
+    #     assert generated_rows.table_values("Child3", 1, "nested_name") == "TheName"
+    #     assert generated_rows.table_values("Child3", -1, "nested_name") == "TheName"


### PR DESCRIPTION
- Refactor YAML loading to use add_representer

The basic idea is to get rid of __getstate__ and __setstate__ methods and make YAML
loading "standalone".

Basically accept that every pickling/serializing "context" should be unique and
orthogonal and not try to reuse them automatically.
