### PR TITLE
Deep Pickles

### DIFF
--- a/snowfakery/utils/pickle.py
+++ b/snowfakery/utils/pickle.py
@@ -7,12 +7,16 @@ import typing as T
 
 import warnings
 
-from snowfakery.object_rows import NicknameSlot, ObjectReference
+from snowfakery.object_rows import NicknameSlot, ObjectReference, ObjectRow
 
 _DISPATCH_TABLE = copyreg.dispatch_table.copy()
 _DISPATCH_TABLE[NicknameSlot] = lambda n: (
     ObjectReference,
     (n._tablename, n.allocated_id),
+)
+_DISPATCH_TABLE[ObjectRow] = lambda v: (
+    ObjectRow,
+    (v._tablename, v._values),
 )
 
 


### PR DESCRIPTION
During Code Review we noticed that recipes that make DEEP references (a.b.c.d)
to objects which are connected by nesting rather than by reference, would not
work because the nested objects are not serialized.

The reason that they were not being deep pickled was because the pickler for Saving rows was detecting some code which had been written for serializing to YAML for continuations in __getstate__. This code bypasses the __getstate__ code.
