### PR TITLE
Serialize just once random_referenced objects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 21.4b2
+    rev: 22.6.0
     hooks:
     - id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/snowfakery/object_rows.py
+++ b/snowfakery/object_rows.py
@@ -70,6 +70,9 @@ class ObjectReference(yaml.YAMLObject):
 
 class LazyLoadedObjectReference(ObjectReference):
     _data = None
+    yaml_loader = yaml.SafeLoader
+    yaml_dumper = SnowfakeryDumper
+    yaml_tag = "!snowfakery_lazyloadedobjectrow"
 
     def __init__(
         self,
@@ -85,9 +88,16 @@ class LazyLoadedObjectReference(ObjectReference):
         if attrname.endswith("__"):  # pragma: no cover
             raise AttributeError(attrname)
         if self._data is None:
-            row_history = RowHistoryCV.get()
-            self._data = row_history.load_row(self.sql_tablename, self.id)
+            self._load_data()
         return self._data[attrname]
+
+    def _load_data(self):
+        row_history = RowHistoryCV.get()
+        self._data = row_history.load_row(self.sql_tablename, self.id)
+
+    def __reduce_ex__(self, *args, **kwargs):
+        self._load_data()
+        return super().__reduce_ex__(*args, **kwargs)
 
 
 class SlotState(Enum):

--- a/tests/deep-random-nesting.yml
+++ b/tests/deep-random-nesting.yml
@@ -1,0 +1,19 @@
+### This recipe creates reference Account record for PMM data
+# Look at examples/salesforce/Account.recipe.yml for more examples.
+
+# Run this like this:
+
+# cci task run generate_and_load_from_yaml --generator_yaml snowfakery_samples/PMM/pmm_0_Account.recipe.yml --num_records 300 --num_records_tablename Account --org qa
+# snowfakery snowfakery_samples/PMM/pmm_0_Account.recipe.yml --output-format json --output-file src/foo.json
+
+# Set Macro for Household and Organization Record Type
+
+- object: Account
+  count: 3
+  just_once: True
+
+- object: Account
+  just_once: True
+  fields:
+    parent:
+      random_reference: Account

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -64,6 +64,7 @@ id_manager:
 nicknames_and_tables: {}
 today: 2022-11-03
 persistent_nicknames: {}
+persistent_random_referenceable_objects: []
                 """
         generate(
             StringIO(yaml),

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -121,7 +121,8 @@ class TestEmbedding:
            Foo: Foo
         persistent_nicknames: {}
         persistent_objects_by_table: {}
-        today: 2021-04-07"""
+        today: 2021-04-07
+        persistent_random_referenceable_objects: []"""
         )
         generate_continuation_file = StringIO()
         decls = """[{"sf_object": Opportunity, "api": bulk}]"""

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -610,15 +610,23 @@ class TestRandomReferencesNew:
     def test_random_reference_to_just_once_obj(self, generated_rows):
         yaml = """
               - object: Parent
+                count: 3
                 just_once: true
+                fields:
+                  name: Poppy
 
               - object: Child
+                count: 5
                 fields:
                   parent:
                     random_reference: Parent
+                  deep_ref: ${{parent.name}}
                 """
         generate(StringIO(yaml), stopping_criteria=StoppingCriteria("Child", 3))
-        assert len(generated_rows.mock_calls) == 4
+        assert len(generated_rows.mock_calls) == 8
+        assert generated_rows.table_values("Child", 1, "deep_ref") == "Poppy"
+        assert generated_rows.table_values("Child", 2, "deep_ref") == "Poppy"
+        assert generated_rows.table_values("Child", 5, "deep_ref") == "Poppy"
 
     @pytest.mark.parametrize("rand_top", [True, False])
     def test_random_reference_to_just_once_obj_many(self, generated_rows, rand_top):


### PR DESCRIPTION
If a just_once template created multiple objects, and was randomly referenced, 
only the most recently created object was saved across continuations. Now they 
are all saved.
