### PR TITLE
Instead of env var BASE_REF, name the local _remote_main_

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ env:
   COVERALLS_PARALLEL: true
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
   SF_MKDOCS_BUILD_LOCALES: "False"
-  BASE_REF: main
 
 jobs:
   test:
@@ -45,7 +44,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v2"
       - run: |
-          git fetch --no-tags origin $BASE_REF:$BASE_REF
+          git fetch --no-tags origin main:_remote_main_
 
       - uses: "actions/setup-python@v1"
         with:
@@ -66,9 +65,8 @@ jobs:
         run: |
           coverage xml
           coverage report
-          echo $BASE_REF
-          git diff HEAD..$BASE_REF
-          diff-cover coverage.xml --fail-under 100 --compare-branch=$BASE_REF --diff-range-notation=.. --show-uncovered --markdown-report coverage.md
+          git diff HEAD.._remote_main_
+          diff-cover coverage.xml --fail-under 100 --compare-branch=_remote_main_ --diff-range-notation=.. --show-uncovered --markdown-report coverage.md
           cat coverage.md >> $GITHUB_STEP_SUMMARY
 
   faker_docs:


### PR DESCRIPTION
There's a failure here:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/22091/191633906-2483fc42-756d-4eba-8632-1ab0bc4a8a23.png">

When both base and branch are "main" it attempts to check it out with the same name twice. This new logic will check it out under two names and then conclude that there is no diff and thus no uncovered lines. When it really is a branch, it should behave as before.