### PR TITLE
Speed up docs build with caching

### DIFF
--- a/tools/faker_docs_utils/mkdocs_plugins/main_mkdocs_plugin.py
+++ b/tools/faker_docs_utils/mkdocs_plugins/main_mkdocs_plugin.py
@@ -1,8 +1,10 @@
+from functools import lru_cache
 from pathlib import Path
 import sys
 import os
 from unittest.mock import patch
 from logging import Logger
+from faker import Factory
 
 from mkdocs.plugins import BasePlugin
 
@@ -37,12 +39,12 @@ class Plugin(BasePlugin):
         #   Disabled due to Faker refactoring. After release can look into
         #   whether it is still needed.
         #
-        # lru_patch = patch(
-        #     "faker.factory.Factory._get_provider_class",
-        #     lru_cache(maxsize=10_000)(Factory._get_provider_class),
-        # )
+        lru_patch = patch(
+            "faker.factory.Factory._find_provider_class",
+            lru_cache(maxsize=10_000)(Factory._find_provider_class),
+        )
 
-        with sys_path_patch, logger_patch:  # lru_patch,
+        with sys_path_patch, logger_patch, lru_patch:
             from tools.faker_docs_utils.faker_markdown import (
                 generate_markdown_for_all_locales,
                 generate_markdown_for_fakers,


### PR DESCRIPTION
This cache was turned off because of a Faker change and the consequences were bad.

With caching, building the Faker docs took about 8[ minutes](https://github.com/SFDO-Tooling/Snowfakery/actions/runs/1650674753/jobs/2229420189).

With no caching, they took 30 [minutes](https://github.com/SFDO-Tooling/Snowfakery/actions/runs/3140455319).

Now they are back to 8 [minutes](https://github.com/SFDO-Tooling/Snowfakery/actions/runs/3155971564/jobs/5135195733)