### PR TITLE
Use CumulusCI source distribution in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           python -VV
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          python -m pip install https://github.com/SFDO-Tooling/CumulusCI/archive/add-pytest-plugins.tar.gz
+          python -m pip install git+https://github.com/SFDO-Tooling/CumulusCI.git@main
 
       - name: Run Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           python -VV
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          python -m pip install cumulusci
+          python -m pip install --no-binary cumulusci cumulusci
 
       - name: Run Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           python -VV
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          python -m pip install --no-binary cumulusci cumulusci
+          python -m pip install https://github.com/SFDO-Tooling/CumulusCI/archive/add-pytest-plugins.tar.gz
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
We removed test subdirectories from our binary distribution of CumulusCI in SFDO-Tooling/CumulusCI/#3476. This broke the `with_cumulusci` job in our CI workflow because of our dependency on a pytest plugin upstream. This PR forces the use of CumulusCI's source distribution (actually the main branch entirely), which does include the subdirectories we need.

We'll switch to using the source distribution after the next release.