### PR TITLE
Unify mocking strategy across all tests.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 default_language_version:
-    python: python3
+  python: python3
 repos:
--   repo: https://github.com/ambv/black
-    rev: 21.4b2
+  - repo: https://github.com/ambv/black
+    rev: 22.3.0
     hooks:
-    - id: black
--   repo: https://github.com/pre-commit/pre-commit-hooks
+      - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:
-    - id: check-merge-conflict
-    - id: flake8
-- repo: local
-  hooks:
-    - id: merge-docs
-      name: Merge examples into docs
-      entry: tools/docs_samples.py
-      language: python
-      files: ".*.md|examples/.*.yml"
+      - id: check-merge-conflict
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: merge-docs
+        name: Merge examples into docs
+        entry: tools/docs_samples.py
+        language: python
+        files: ".*.md|examples/.*.yml"

--- a/snowfakery/data_generator.py
+++ b/snowfakery/data_generator.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import IO, Tuple, Mapping, List, Dict, TextIO, Union
+from typing import IO, Optional, Tuple, Mapping, List, Dict, TextIO, Union
 import typing as T
 import functools
 
@@ -120,9 +120,9 @@ def process_plugins(plugins: List) -> Tuple[List[object], Mapping[str, object]]:
 
 def generate(
     open_yaml_file: IO[str],
-    user_options: dict = None,
+    user_options: Optional[dict] = None,
     #  *,   TODO: fix test suite so these can be keyword-only arguments
-    output_stream: OutputStream = None,
+    output_stream: Optional[OutputStream] = None,
     parent_application=None,
     *,
     stopping_criteria=None,

--- a/tests/standard_functions/test_distributions.py
+++ b/tests/standard_functions/test_distributions.py
@@ -6,14 +6,11 @@ import pytest
 from snowfakery.data_generator import generate
 from snowfakery.data_gen_exceptions import DataGenError
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_single_row"
-
 pytest.importorskip("numpy")
 
 
 class TestStatisticalDistributions:
-    @mock.patch(write_row_path)
-    def test_random_distribution_normal(self, write_row):
+    def test_random_distribution_normal(self, generated_rows):
         yaml = """
         - plugin: snowfakery.standard_plugins.statistical_distributions.StatisticalDistributions
         - object: A
@@ -25,11 +22,10 @@ class TestStatisticalDistributions:
                 seed: 1
         """
         generate(StringIO(yaml), {}, None)
-        assert len(write_row.mock_calls) == 1
-        assert write_row.mock_calls == [mock.call("A", {"id": 1, "b": 3})]
+        assert len(generated_rows.mock_calls) == 1
+        assert generated_rows.mock_calls == [mock.call("A", {"id": 1, "b": 3})]
 
-    @mock.patch(write_row_path)
-    def test_random_distribution_param_errors(self, write_row):
+    def test_random_distribution_param_errors(self, generated_rows):
         yaml = """
         - plugin: snowfakery.standard_plugins.statistical_distributions.StatisticalDistributions
         - object: A
@@ -44,8 +40,7 @@ class TestStatisticalDistributions:
             generate(StringIO(yaml), {}, None)
         assert "lognormal" in str(e.value)
 
-    @mock.patch(write_row_path)
-    def test_random_distribution_unknown(self, write_row):
+    def test_random_distribution_unknown(self, generated_rows):
         yaml = """
         - plugin: snowfakery.standard_plugins.statistical_distributions.StatisticalDistributions
         - object: A

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,19 +20,16 @@ sample_yaml = Path(__file__).parent / "include_parent.yml"
 bad_sample_yaml = Path(__file__).parent / "include_bad_parent.yml"
 sample_accounts_yaml = Path(__file__).parent / "gen_sf_standard_objects.yml"
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_single_row"
-
 
 class TestGenerateFromCLI:
-    @mock.patch(write_row_path)
-    def test_simple(self, write_row):
+    def test_simple(self, generated_rows):
         generate_cli.callback(
             yaml_file=sample_yaml,
             option={},
             debug_internals=None,
             generate_cci_mapping_file=None,
         )
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call(
                 "Account",
                 {"id": 1, "name": "Default Company Name", "ShippingCountry": "Canada"},
@@ -43,8 +40,7 @@ class TestGenerateFromCLI:
         assert eval_arg("5") == 5
         assert eval_arg("abc") == "abc"
 
-    @mock.patch(write_row_path)
-    def test_counts(self, write_row):
+    def test_counts(self, generated_rows):
         generate_cli.callback(
             yaml_file=sample_yaml,
             target_number=(2, "Account"),
@@ -52,7 +48,7 @@ class TestGenerateFromCLI:
             debug_internals=None,
             generate_cci_mapping_file=None,
         )
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call(
                 "Account",
                 {"id": 1, "name": "Default Company Name", "ShippingCountry": "Canada"},
@@ -63,8 +59,7 @@ class TestGenerateFromCLI:
             ),
         ]
 
-    @mock.patch(write_row_path)
-    def test_counts_backwards(self, write_row):
+    def test_counts_backwards(self, generated_rows):
         generate_cli.callback(
             yaml_file=sample_yaml,
             target_number=("Account", 2),
@@ -72,7 +67,7 @@ class TestGenerateFromCLI:
             debug_internals=None,
             generate_cci_mapping_file=None,
         )
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call(
                 "Account",
                 {"id": 1, "name": "Default Company Name", "ShippingCountry": "Canada"},
@@ -83,8 +78,7 @@ class TestGenerateFromCLI:
             ),
         ]
 
-    @mock.patch(write_row_path)
-    def test_with_option(self, write_row):
+    def test_with_option(self, generated_rows):
         with pytest.warns(UserWarning):
             generate_cli.callback(
                 yaml_file=sample_yaml,
@@ -93,8 +87,7 @@ class TestGenerateFromCLI:
                 generate_cci_mapping_file=None,
             )
 
-    @mock.patch(write_row_path)
-    def test_with_bad_dburl(self, write_row):
+    def test_with_bad_dburl(self, generated_rows):
         with pytest.raises(Exception):
             generate_cli.callback(
                 yaml_file=sample_yaml,
@@ -104,12 +97,10 @@ class TestGenerateFromCLI:
                 generate_cci_mapping_file=None,
             )
 
-    @mock.patch(write_row_path)
-    def test_with_debug_flags_on(self, write_row):
+    def test_with_debug_flags_on(self, generated_rows):
         generate_cli.callback(yaml_file=sample_yaml, option={}, debug_internals=True)
 
-    @mock.patch(write_row_path)
-    def test_exception_with_debug_flags_on(self, write_row):
+    def test_exception_with_debug_flags_on(self, generated_rows):
         with named_temporary_file_path(suffix=".yml") as t:
             with pytest.raises(DataGenError):
                 generate_cli.callback(
@@ -120,8 +111,7 @@ class TestGenerateFromCLI:
                 )
                 assert yaml.safe_load(t)
 
-    @mock.patch(write_row_path)
-    def test_exception_with_debug_flags_off(self, write_row):
+    def test_exception_with_debug_flags_off(self, generated_rows):
         with named_temporary_file_path(suffix=".yml") as t:
             with pytest.raises(ClickException):
                 generate_cli.callback(

--- a/tests/test_continuation.py
+++ b/tests/test_continuation.py
@@ -1,4 +1,3 @@
-from unittest import mock
 from io import StringIO
 
 from snowfakery.data_generator import generate
@@ -36,8 +35,7 @@ class TestContinuation:
         assert generated_rows.row_values(3, "foo_reference") == "foo(1)"
         assert generated_rows.row_values(4, "bar_reference") == "bar(2)"
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_ids_go_up(self, write_row):
+    def test_ids_go_up(self, generated_rows):
         yaml = """
             - object: foo
               count: 5
@@ -49,7 +47,7 @@ class TestContinuation:
             StringIO(yaml), continuation_file=StringIO(continuation_file.getvalue())
         )
 
-        assert write_row.mock_calls[-1][1][1]["id"] == 10
+        assert generated_rows.mock_calls[-1][1][1]["id"] == 10
 
     def test_forward_references_work_after_restart(self, generated_rows):
         yaml = """
@@ -67,8 +65,7 @@ class TestContinuation:
 
         assert generated_rows.table_values("Foo", 2, "bar") == "Bar(2)"
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_faker_dates_work(self, write_row):
+    def test_faker_dates_work(self, generated_rows):
         yaml = """
             - object: foo
               just_once: True
@@ -82,8 +79,7 @@ class TestContinuation:
         generate(StringIO(yaml), generate_continuation_file=continuation_file)
         assert "a_date" in continuation_file.getvalue()
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_circular_references(self, write_row):
+    def test_circular_references(self, generated_rows):
         yaml_data = """
             - object: parent
               nickname: TheParent

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -48,8 +48,7 @@ class TestDataGenerator:
             generate(StringIO(yaml), {"qwerty": "EBCDIC"})
         assert "xyzzy" in str(e.value)
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_stopping_criteria_with_startids(self, write_row):
+    def test_stopping_criteria_with_startids(self, generated_rows):
         yaml = """
             - object: foo
               just_once: True
@@ -70,29 +69,27 @@ persistent_nicknames: {}
             continuation_file=StringIO(continuation_yaml),
             stopping_criteria=StoppingCriteria("bar", 3),
         )
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call("bar", {"id": 1001}),
             mock.call("bar", {"id": 1002}),
             mock.call("bar", {"id": 1003}),
         ]
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_stopping_criteria_and_just_once(self, write_row):
+    def test_stopping_criteria_and_just_once(self, generated_rows):
         yaml = """
         - object: foo
           just_once: True
         - object: bar
         """
         generate(StringIO(yaml), stopping_criteria=StoppingCriteria("bar", 3))
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call("foo", {"id": 1}),
             mock.call("bar", {"id": 1}),
             mock.call("bar", {"id": 2}),
             mock.call("bar", {"id": 3}),
         ]
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_stops_on_no_progress(self, write_row):
+    def test_stops_on_no_progress(self, generated_rows):
         yaml = """
         - object: foo
           just_once: True
@@ -101,8 +98,7 @@ persistent_nicknames: {}
         with pytest.raises(RuntimeError):
             generate(StringIO(yaml), stopping_criteria=StoppingCriteria("foo", 3))
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_stops_if_criteria_misspelled(self, write_row):
+    def test_stops_if_criteria_misspelled(self, generated_rows):
         yaml = """
         - object: foo
           just_once: True

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,18 +1,14 @@
 from io import StringIO
-from unittest import mock
 
 from snowfakery.data_generator import generate
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_row"
 
-
-def row_values(write_row_mock, index, value):
-    return write_row_mock.mock_calls[index][1][1][value]
+def row_values(generated_rows, index, value):
+    return generated_rows.mock_calls[index][1][1][value]
 
 
 class Testi18n:
-    @mock.patch(write_row_path)
-    def test_i18n(self, write_row_mock):
+    def test_i18n(self, generated_rows):
         yaml = """
         - object: foo
           fields:
@@ -21,4 +17,4 @@ class Testi18n:
                     locale: ja_JP
                     fake: name"""
         generate(StringIO(yaml), {})
-        assert isinstance(row_values(write_row_mock, 0, "japanese_name"), str)
+        assert isinstance(row_values(generated_rows, 0, "japanese_name"), str)

--- a/tests/test_inclusions.py
+++ b/tests/test_inclusions.py
@@ -1,27 +1,22 @@
-from unittest import mock
 import pathlib
 import pytest
 
 from snowfakery.data_generator import generate
 from snowfakery.data_gen_exceptions import DataGenError
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_row"
-
 
 class TestReferences:
-    @mock.patch(write_row_path)
-    def test_included_file(self, write_row):
+    def test_included_file(self, generated_rows):
         include_parent = pathlib.Path(__file__).parent / "include_parent.yml"
         with open(include_parent) as f:
             generate(f, {}, None)
 
-        write_row.assert_called_with(
+        generated_rows.assert_called_with(
             "Account",
             {"id": 1, "name": "Default Company Name", "ShippingCountry": "Canada"},
         )
 
-    @mock.patch(write_row_path)
-    def test_failed_include_file(self, write_row):
+    def test_failed_include_file(self, generated_rows):
         failed_include = pathlib.Path(__file__).parent / "include_bad_parent.yml"
         with pytest.raises(DataGenError):
             with open(failed_include) as f:

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -5,12 +5,9 @@ import pytest
 from snowfakery.data_generator import generate
 import snowfakery.data_gen_exceptions as exc
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_row"
-
 
 class TestMacros:
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_field_includes(self, write_row):
+    def test_field_includes(self, generated_rows):
         yaml = """
         - macro: standard_foo
           fields:
@@ -22,10 +19,11 @@ class TestMacros:
             baz: 6
         """
         generate(StringIO(yaml))
-        assert write_row.mock_calls == [mock.call("foo", {"id": 1, "bar": 5, "baz": 6})]
+        assert generated_rows.mock_calls == [
+            mock.call("foo", {"id": 1, "bar": 5, "baz": 6})
+        ]
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_friend_includes(self, write_row):
+    def test_friend_includes(self, generated_rows):
         yaml = """
         - macro: standard_foo
           friends:
@@ -35,13 +33,12 @@ class TestMacros:
           include: standard_foo
         """
         generate(StringIO(yaml))
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call("foo", {"id": 1}),
             mock.call("bar", {"id": 1}),
         ]
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_field_and_friend_includes(self, write_row):
+    def test_field_and_friend_includes(self, generated_rows):
         yaml = """
         - macro: standard_foo
           fields:
@@ -56,13 +53,12 @@ class TestMacros:
           include: standard_foo
         """
         generate(StringIO(yaml))
-        assert write_row.mock_calls == [
+        assert generated_rows.mock_calls == [
             mock.call("foo", {"id": 1, "bar": 5}),
             mock.call("baz", {"id": 1, "zar": 6}),
         ]
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_friend_includes_and_references(self, write_row):
+    def test_friend_includes_and_references(self, generated_rows):
         yaml = """
         - macro: standard_foo
           friends:
@@ -75,12 +71,11 @@ class TestMacros:
           include: standard_foo
         """
         generate(StringIO(yaml))
-        assert write_row.mock_calls[0] == mock.call("foo", {"id": 1})
-        assert write_row.mock_calls[1][1][0] == "bar"
-        assert write_row.mock_calls[1][1][1]["myfoo"].id == 1
+        assert generated_rows.mock_calls[0] == mock.call("foo", {"id": 1})
+        assert generated_rows.mock_calls[1][1][0] == "bar"
+        assert generated_rows.mock_calls[1][1][1]["myfoo"] == "foo(1)"
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_macros_include_macros(self, write_row):
+    def test_macros_include_macros(self, generated_rows):
         yaml = """
         - macro: foo
           fields:
@@ -95,12 +90,11 @@ class TestMacros:
           include: bar
         """
         generate(StringIO(yaml))
-        assert write_row.mock_calls[0] == mock.call(
+        assert generated_rows.mock_calls[0] == mock.call(
             "Bar", {"id": 1, "barbar": "BARBAR", "foobar": "FOOBAR"}
         )
 
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_macros_include_themselves(self, write_row):
+    def test_macros_include_themselves(self, generated_rows):
         yaml = """
         - macro: foo
           include: bar

--- a/tests/test_parse_samples.py
+++ b/tests/test_parse_samples.py
@@ -22,18 +22,14 @@ def find_row(row_type, compare, calls):
             return row_values  # return the args
 
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_row"
-
-
 class TestParseAndOutput:
-    @mock.patch(write_row_path)
-    def test_d_and_d(self, write_row):
+    def test_d_and_d(self, generated_rows):
         with open(dnd_test) as open_yaml_file:
             generate(
                 open_yaml_file=open_yaml_file,
                 user_options={"num_fighters": 1, "num_druids": 2},
             )
-        calls = write_row.mock_calls
+        calls = generated_rows.mock_calls
         assert find_row("Equipment", {"id": 1}, calls)
         assert find_row("Druid", {"id": 1, "Hit Points": mock.ANY}, calls)
         assert find_row("Druid", {"id": 2, "Hit Points": mock.ANY}, calls)
@@ -41,11 +37,10 @@ class TestParseAndOutput:
         assert not find_row("Fighter", {"id": 2, "Name": mock.ANY}, calls)
         assert find_row("Paladin", {"id": 1, "Name": mock.ANY}, calls)
 
-    @mock.patch(write_row_path)
-    def test_data_imports(self, write_row):
+    def test_data_imports(self, generated_rows):
         with open(data_imports) as open_yaml_file:
             generate(open_yaml_file, {"total_data_imports": 4}, None)
-        calls = write_row.mock_calls
+        calls = generated_rows.mock_calls
         assert find_row(
             "General_Accounting_Unit__c", {"id": 1, "Name": "Scholarship"}, calls
         )
@@ -66,34 +61,31 @@ class TestParseAndOutput:
             calls,
         )
 
-    @mock.patch(write_row_path)
-    def test_gen_standard_objects(self, write_row):
+    def test_gen_standard_objects(self, generated_rows):
         with open(standard_objects) as open_yaml_file:
             generate(open_yaml_file, {}, None)
 
-        calls = write_row.mock_calls
+        calls = generated_rows.mock_calls
 
         assert find_row("Account", {}, calls)
         assert find_row("Contact", {}, calls)
         assert find_row("Opportunity", {}, calls)
 
-    @mock.patch(write_row_path)
-    def test_gen_npsp_standard_objects(self, write_row):
+    def test_gen_npsp_standard_objects(self, generated_rows):
         with open(npsp_standard_objects) as open_yaml_file:
             generate(open_yaml_file, {}, None)
 
-        calls = write_row.mock_calls
+        calls = generated_rows.mock_calls
 
         assert find_row("Account", {}, calls)
         assert find_row("Contact", {}, calls)
         assert find_row("Opportunity", {}, calls)
 
-    @mock.patch(write_row_path)
-    def test_simple_salesforce(self, write_row):
+    def test_simple_salesforce(self, generated_rows):
         with open(simple_salesforce) as open_yaml_file:
             generate(open_yaml_file, {}, None)
 
-        calls = write_row.mock_calls
+        calls = generated_rows.mock_calls
 
         assert find_row("Account", {}, calls)
         assert find_row("Contact", {}, calls)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -53,16 +53,13 @@ reference_from_friend = """             #1
                 reference: A            #7
     """
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_single_row"
-
 
 class TestReferences:
-    @mock.patch(write_row_path)
-    def test_simple_parent(self, write_row):
+    def test_simple_parent(self, generated_rows):
         generate(StringIO(simple_parent), {}, None)
 
-        a_values = find_row("A", {}, write_row.mock_calls)
-        b_values = find_row("B", {}, write_row.mock_calls)
+        a_values = find_row("A", {}, generated_rows.mock_calls)
+        b_values = find_row("B", {}, generated_rows.mock_calls)
         id_a = a_values["id"]
         reference_b = a_values["B"]
         id_b = b_values["id"]
@@ -70,12 +67,11 @@ class TestReferences:
         assert f"A({id_a})" == reference_a
         assert f"B({id_b})" == reference_b
 
-    @mock.patch(write_row_path)
-    def test_simple_parent_list_child(self, write_row):
+    def test_simple_parent_list_child(self, generated_rows):
         generate(StringIO(simple_parent_list), {}, None)
 
-        a_values = find_row("A", {}, write_row.mock_calls)
-        b_values = find_row("B", {}, write_row.mock_calls)
+        a_values = find_row("A", {}, generated_rows.mock_calls)
+        b_values = find_row("B", {}, generated_rows.mock_calls)
         id_a = a_values["id"]
         reference_b = a_values["B"]
         id_b = b_values["id"]
@@ -83,28 +79,25 @@ class TestReferences:
         assert f"A({id_a})" == reference_a
         assert f"B({id_b})" == reference_b
 
-    @mock.patch(write_row_path)
-    def test_ancestor_reference(self, write_row):
+    def test_ancestor_reference(self, generated_rows):
         generate(StringIO(ancestor_reference), {}, None)
 
-        a_values = find_row("A", {}, write_row.mock_calls)
-        c_values = find_row("C", {}, write_row.mock_calls)
+        a_values = find_row("A", {}, generated_rows.mock_calls)
+        c_values = find_row("C", {}, generated_rows.mock_calls)
         id_a = a_values["id"]
         reference_a = c_values["A_ref"]
         assert f"A({id_a})" == reference_a
 
-    @mock.patch(write_row_path)
-    def test_reference_from_friend(self, write_row):
+    def test_reference_from_friend(self, generated_rows):
         generate(StringIO(reference_from_friend), {}, None)
 
-        a_values = find_row("A", {}, write_row.mock_calls)
-        b_values = find_row("B", {}, write_row.mock_calls)
+        a_values = find_row("A", {}, generated_rows.mock_calls)
+        b_values = find_row("B", {}, generated_rows.mock_calls)
         id_a = a_values["id"]
         reference_a = b_values["A_ref"]
         assert f"A({id_a})" == reference_a
 
-    @mock.patch(write_row_path)
-    def test_forward_reference(self, write_row):
+    def test_forward_reference(self, generated_rows):
         yaml = """
         - object: A
           fields:
@@ -118,13 +111,12 @@ class TestReferences:
         """
         generate(StringIO(yaml), {}, None)
 
-        a_values = find_row("A", {}, write_row.mock_calls)
-        b_values = find_row("B", {}, write_row.mock_calls)
+        a_values = find_row("A", {}, generated_rows.mock_calls)
+        b_values = find_row("B", {}, generated_rows.mock_calls)
         assert a_values["B"] == "B(1)"
         assert b_values["A"] == "A(1)"
 
-    @mock.patch(write_row_path)
-    def test_forward_reference__tablename(self, write_row):
+    def test_forward_reference__tablename(self, generated_rows):
         yaml = """
             - object: A
               fields:
@@ -138,13 +130,12 @@ class TestReferences:
                     A
               """
         generate(StringIO(yaml), {}, None)
-        a_values = find_row("A", {}, write_row.mock_calls)
-        b_values = find_row("B", {}, write_row.mock_calls)
+        a_values = find_row("A", {}, generated_rows.mock_calls)
+        b_values = find_row("B", {}, generated_rows.mock_calls)
         assert a_values["B"] == "B(1)"
         assert b_values["A"] == "A(1)"
 
-    @mock.patch(write_row_path)
-    def test_forward_reference_not_fulfilled(self, write_row):
+    def test_forward_reference_not_fulfilled(self, generated_rows):
         yaml = """
         - object: A
           fields:
@@ -180,8 +171,7 @@ class TestReferences:
             generate(StringIO(yaml), {}, None)
         assert "BBB" in str(e.value)
 
-    @mock.patch(write_row_path)
-    def test_forward_references_not_fulfilled__nickname(self, write_row):
+    def test_forward_references_not_fulfilled__nickname(self, generated_rows):
         yaml = """
         - object: A
           fields:

--- a/tests/test_structured_values.py
+++ b/tests/test_structured_values.py
@@ -1,5 +1,4 @@
 from io import StringIO
-from unittest import mock
 
 
 from snowfakery.data_generator import generate
@@ -15,18 +14,13 @@ structured_values_with_templates = """  #1
 """
 
 
-write_row_path = "snowfakery.output_streams.DebugOutputStream.write_row"
-
-
 class TestStructuredValues:
-    @mock.patch(write_row_path)
-    def test_structured_values(self, write_row):
+    def test_structured_values(self, generated_rows):
         generate(StringIO(structured_values_with_templates), {}, None)
-        assert isinstance(write_row.mock_calls[0][1][1]["B"], int)
-        assert 2 <= write_row.mock_calls[0][1][1]["B"] <= 8
+        assert isinstance(generated_rows.mock_calls[0][1][1]["B"], int)
+        assert 2 <= generated_rows.mock_calls[0][1][1]["B"] <= 8
 
-    @mock.patch(write_row_path)
-    def test_lazy_random_choice(self, write_row):
+    def test_lazy_random_choice(self, generated_rows):
         yaml = """
         - object : A
           fields:
@@ -37,4 +31,4 @@ class TestStructuredValues:
                     - object: E
         """
         generate(StringIO(yaml), {}, None)
-        assert len(write_row.mock_calls) == 2, write_row.mock_calls
+        assert len(generated_rows.mock_calls) == 2, generated_rows.mock_calls

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,20 +1,18 @@
 import pytest
-from unittest import mock
 from io import StringIO
 
 from snowfakery.data_generator import generate
 
 
 class TestTypes:
-    @mock.patch("snowfakery.output_streams.DebugOutputStream.write_row")
-    def test_empty_string(self, write_row):
+    def test_empty_string(self, generated_rows):
         yaml = """
             - object: Foo
               fields:
                 bar: ""
         """
         generate(StringIO(yaml))
-        assert write_row.mock_calls[0][1][1]["bar"] == ""
+        assert generated_rows.mock_calls[0][1][1]["bar"] == ""
 
     def test_zero_prefixed_string(self, generated_rows):
         yaml = """


### PR DESCRIPTION
Snowfakery has updated its output-mocking strategy over the years.

An upcoming change needs pervasive changes to all output-mocks.

So this PR also centralized all of them through a single fixture called 
generated_rows. Lots of old code like this:

    @mock.patch(write_row_path)
    def test_gen_standard_objects(self, write_row):
        with open(standard_objects) as open_yaml_file:
            generate(open_yaml_file, {}, None)

        calls = write_row.mock_calls

Is updated to modern syntax:

    def test_gen_standard_objects(self, generated_rows):
        with open(standard_objects) as open_yaml_file:
            generate(open_yaml_file, {}, None)

        calls = generated_rows.mock_calls

