### PR TITLE
Clean up warnings in tests and at runtime.

### DIFF
--- a/snowfakery/data_generator_runtime.py
+++ b/snowfakery/data_generator_runtime.py
@@ -426,7 +426,7 @@ class Interpreter:
             try:
                 plugin.close()
             except Exception as e:
-                warn(f"Could not close {plugin} because {e}")
+                warn(f"Could not close {plugin} because {repr(e)}")
         self.current_context = None
         self.plugin_instances = None
         self.plugin_function_libraries = None

--- a/snowfakery/standard_plugins/Schedule.py
+++ b/snowfakery/standard_plugins/Schedule.py
@@ -236,7 +236,7 @@ class CalendarRule(PluginResultIterator):
             add_date = self.ruleset.rdate
         else:  # pragma: no cover   -   Should be unreachable
             assert action in ("include", "exclude"), "Bad action!"
-            raise NotImplementedError()
+            raise NotImplementedError("Bad action!")
 
         if isinstance(case, (list, tuple)):
             for case in case:
@@ -338,7 +338,7 @@ class CalendarRule(PluginResultIterator):
         """This method is never called.
 
         It is replaced at runtime by _next_datetime or _next_date"""
-        raise NotImplementedError()
+        raise NotImplementedError("next is not implemented")
 
     def _next_datetime(self) -> datetime:
         return next(self.iterator)

--- a/snowfakery/standard_plugins/datasets.py
+++ b/snowfakery/standard_plugins/datasets.py
@@ -190,13 +190,17 @@ class DatasetBase:
         return dataset_instance
 
     def _load_dataset(self, iteration_mode, rootpath, kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError("_load_dataset not implemented")
 
     def close(self):
-        raise NotImplementedError()
+        raise NotImplementedError("close not implemented: " + repr(self))
 
 
 class FileDataset(DatasetBase):
+
+    def close(self):
+        pass
+    
     def _load_dataset(self, iteration_mode, rootpath, kwargs):
         dataset = kwargs.get("dataset")
         tablename = kwargs.get("table")


### PR DESCRIPTION
In snowfakery/data_generator_runtime.py : print more information about the exception by using repr(e) instead of str(e)

In several other files, put a message in every NotImplementeError

And make sure that FileDatasets have a close() method so it doesn't generate warnings.
