### PR TITLE
Clean up temporary directories after closing iterator

### DIFF
--- a/snowfakery/standard_plugins/Salesforce.py
+++ b/snowfakery/standard_plugins/Salesforce.py
@@ -330,26 +330,14 @@ class SOQLDatasetImpl(DatasetBase):
                 f"Unable to query records for {query}: {','.join(qs.job_result.job_errors)}"
             )
 
-        self.tempdir, self.iterator = create_tempfile_sql_db_iterator(
+        tempdir, iterator = create_tempfile_sql_db_iterator(
             iteration_mode, fieldnames, qs.get_results()
         )
-        return self.iterator
+        iterator.cleanup.push(tempdir)
+        return iterator
 
     def close(self):
-        if self.iterator:
-            self.iterator.close()
-            self.iterator = None
-
-        if self.tempdir:
-            self.tempdir.cleanup()
-            self.tempdir = None
-
-    def __del__(self):
-        # in case close was not called
-        # properly, try to do an orderly
-        # cleanup
-        self.close()
-
+        pass
 
 def create_tempfile_sql_db_iterator(mode, fieldnames, results):
     tempdir, db_url = _create_db(fieldnames, results)

--- a/snowfakery/standard_plugins/datasets.py
+++ b/snowfakery/standard_plugins/datasets.py
@@ -66,8 +66,16 @@ class DatasetIteratorBase(PluginResultIterator):
     Subclasses should implement 'self.restart' which puts an iterator into 'self.results'
     """
 
+    def __init__(self, repeat):
+        # subclasses can register stuff to be cleaned up here.
+        self.cleanup = ExitStack()
+        super().__init__(repeat)
+
     def next_result(self):
         return next(self.results)
+
+    def close(self):
+        self.cleanup.close()
 
 
 class SQLDatasetIterator(DatasetIteratorBase):
@@ -86,6 +94,7 @@ class SQLDatasetIterator(DatasetIteratorBase):
     def close(self):
         self.results = None
         self.connection.close()
+        super().close()
 
     def query(self):
         "Return a SQL Alchemy SELECT statement"
@@ -108,14 +117,13 @@ class SQLDatasetRandomPermutationIterator(SQLDatasetIterator):
 
 class CSVDatasetLinearIterator(DatasetIteratorBase):
     def __init__(self, datasource: FileLike, repeat: bool):
-        self.cleanup = ExitStack()
+        super().__init__(repeat)
         # utf-8-sig and newline="" are for Windows
         self.path, self.file = self.cleanup.enter_context(
             open_file_like(datasource, "r", newline="", encoding="utf-8-sig")
         )
 
         self.start()
-        super().__init__(repeat)
 
     def start(self):
         assert self.file
@@ -127,7 +135,7 @@ class CSVDatasetLinearIterator(DatasetIteratorBase):
 
     def close(self):
         self.results = None
-        self.cleanup.close()
+        super().close()
 
     def plugin_result(self, row):
         if None in row:

--- a/tests/multiple-datasets.yml
+++ b/tests/multiple-datasets.yml
@@ -1,0 +1,17 @@
+- plugin: snowfakery.standard_plugins.Salesforce.SOQLDataset
+- object: Contact
+  count: 10
+  fields:
+    __users_from_salesforce:
+      SOQLDataset.shuffle:
+        fields: Id, FirstName, LastName
+        from: User
+    __Account_from_Salesforce:
+      SOQLDataset.shuffle:
+        fields: Id
+        from: Account
+    # The next line depends on the users having particular
+    # permissions.
+    FirstName: ${{__users_from_salesforce.FirstName}}
+    LastName: ${{__users_from_salesforce.LastName}}
+    AccountId: ${{__Account_from_Salesforce.Id}}


### PR DESCRIPTION
Fixes #901

What was happening on Windows is that that the temporary directory was being garbage collected before the open file handle temporary file inside of it. This was probably also handling on *ix, but it was harmless.

On Windows, the temporary directory object needs to live a bit longer than the local tempfile, which needs to live a bit longer than than the SQL Alchemy connection to the tempfile.

So I use an ExitStack to inject cleanup code which is run before the connection is closed and the file handle is released.

All of this is triggered by the garbage collector letting go of the iterator when the recipe is finishing up.

It might be better to do a deterministic, explicit, top-down cleanup, but that should probably be a different PR.