### PR TITLE
Fix incorrect parameter name in documentation

### DIFF
--- a/docs/salesforce.md
+++ b/docs/salesforce.md
@@ -241,7 +241,7 @@ If you have a recipe which depends on data from an org,
 specify the CumulusCI org name like this:
 
 ```s
-$ snowfakery recipe.yml --plugin-options org_name qa
+$ snowfakery recipe.yml --plugin-option org_name qa
 ```
 
 When you run the recipe in this way, it will connect to the org to pull data but


### PR DESCRIPTION
This PR aims to resolve #1024 by correcting the parameter name in the documentation from `--plugin-options` to `--plugin-option`.

This ensures the documentation accurately reflects the correct parameter usage.





